### PR TITLE
2.0.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kiwilan/php-ebook",
     "description": "PHP package to read metadata and extract covers from eBooks (.epub, .cbz, .cbr, .cb7, .cbt, .pdf) and audiobooks (.mp3, .m4a, .m4b, .flac, .ogg).",
-    "version": "2.0.1",
+    "version": "2.0.11",
     "keywords": [
         "php",
         "ebook",

--- a/src/Formats/Epub/OpfMetadata.php
+++ b/src/Formats/Epub/OpfMetadata.php
@@ -441,7 +441,7 @@ class OpfMetadata
             if (is_string($item)) {
                 $item = ['@content' => $item];
             }
-            $items[] = $item['@content'];
+            $items[] = XmlReader::parseContent($item);
         }
 
         return $items;
@@ -514,7 +514,7 @@ class OpfMetadata
             $attr = XmlReader::parseAttributes($items);
 
             // Check if bad multiple creators `Jean M. Auel, Philippe Rouard` exists
-            if (str_contains($content, ',')) {
+            if (is_string($content) && str_contains($content, ',')) {
                 $content = explode(',', $content);
                 $content = array_map('trim', $content);
             }

--- a/tests/EpubTest.php
+++ b/tests/EpubTest.php
@@ -158,7 +158,10 @@ it('can parse epub without tags', function () {
 });
 
 it('can handle bad file', function () {
-    expect(fn () => Ebook::read(EPUB_BAD_FILE))->toThrow(ValueError::class);
+    $ebook = Ebook::read(EPUB_BAD_FILE);
+
+    expect($ebook->hasMetadata())->toBeFalse();
+    expect($ebook->isBadFile())->toBeTrue();
 });
 
 it('can handle bad epub', function (string $epub) {


### PR DESCRIPTION
- add `Epub` property `isBadFile` to check if the file is corrupted, eBook file will be read but not parsed if it is corrupted, it's possible to know if file is valid with `isBadFile()` method or with `hasMetadata()` method
- fix some problems with OPF parsing to be more flexible