### PR TITLE
Add check if XML reader cannot parse content

### DIFF
--- a/src/Formats/Epub/OpfMetadata.php
+++ b/src/Formats/Epub/OpfMetadata.php
@@ -384,6 +384,9 @@ class OpfMetadata
 
         foreach ($core as $item) {
             $name = XmlReader::parseContent($item);
+            if(is_array($name)){
+                continue;
+            }
             $attributes = XmlReader::parseAttributes($item);
             $items[$name] = new BookAuthor(
                 name: $name,


### PR DESCRIPTION
If the item does not have a `@content` entry, XML reader will return an array, which will crash the `BookAuthor` constructor, because `$name` is not a string