### PR TITLE
2.0.20

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -15,9 +15,10 @@ jobs:
     steps:
       - name: Install for Linux
         run: |
+          sudo apt update
           sudo apt -y install p7zip-full ghostscript imagemagick
-          sudo apt-get install -y unrar
-          sudo apt-get install -y libunrar-dev
+          sudo apt install -y unrar
+          sudo apt install -y libunrar-dev
           sudo sed -i '/disable ghostscript format types/,+6d' /etc/ImageMagick-6/policy.xml
         shell: bash
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,9 +17,10 @@ jobs:
     steps:
       - name: Install
         run: |
+          sudo apt update
           sudo apt -y install p7zip-full ghostscript imagemagick
-          sudo apt-get install -y unrar
-          sudo apt-get install -y libunrar-dev
+          sudo apt install -y unrar
+          sudo apt install -y libunrar-dev
           sudo sed -i '/disable ghostscript format types/,+6d' /etc/ImageMagick-6/policy.xml
         shell: bash
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ $ebook->getMetadata(); // ?EbookMetadata => metadata with parsers
 $ebook->getMetaTitle(); // ?MetaTitle, with slug and sort properties for `title` and `series`
 $ebook->getFormat(); // ?EbookFormatEnum => `epub`, `pdf`, `cba`
 $ebook->getCover(); // ?EbookCover => cover of book
+$ebook->getArchive(); // ?BaseArchive => archive of book from `kiwilan/php-archive`
 ```
 
 And to test if some data exists:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ $ebook->getTitle(); // string
 $ebook->getAuthors(); // BookAuthor[] (`name`: string, `role`: string)
 $ebook->getAuthorMain(); // ?BookAuthor => First BookAuthor (`name`: string, `role`: string)
 $ebook->getDescription(); // ?string
+$ebook->getDescriptionHtml(); // ?string
 $ebook->getCopyright(); // ?string
 $ebook->getPublisher(); // ?string
 $ebook->getIdentifiers(); // BookIdentifier[] (`value`: string, `scheme`: string)

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed re
 
 -   [`spatie`](https://github.com/spatie) for `spatie/package-skeleton-php`
 -   [`kiwilan`](https://github.com/kiwilan) for `kiwilan/php-archive`, `kiwilan/php-audio`, `kiwilan/php-xml-reader`
+-   [All Contributors](../../contributors)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -98,8 +98,6 @@ composer require kiwilan/php-ebook
 
 ## Usage
 
-### Main
-
 With eBook files (`.epub`, `.cbz`, `.cba`, `.cbr`, `.cb7`, `.cbt`, `.pdf`) or audiobook files (`mp3`, `m4a`, `m4b`, `flac`, `ogg`).
 
 ```php
@@ -141,6 +139,14 @@ Some metadata can be stored into `extras()` method, without typing, directly fro
 ```php
 $ebook->getExtras(); // array<string, mixed> => additional data for book
 $ebook->getExtra(string $key); // mixed => safely extract data from `extras` array
+```
+
+To know if eBook is valid, you can use `isValid()` static method, before `read()`.
+
+```php
+use Kiwilan\Ebook\Ebook;
+
+$isValid = Ebook::isValid('path/to/ebook.epub');
 ```
 
 To get additional data, you can use these methods:

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kiwilan/php-ebook",
     "description": "PHP package to read metadata and extract covers from eBooks (.epub, .cbz, .cbr, .cb7, .cbt, .pdf) and audiobooks (.mp3, .m4a, .m4b, .flac, .ogg).",
-    "version": "2.0.13",
+    "version": "2.0.20",
     "keywords": [
         "php",
         "ebook",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kiwilan/php-ebook",
     "description": "PHP package to read metadata and extract covers from eBooks (.epub, .cbz, .cbr, .cb7, .cbt, .pdf) and audiobooks (.mp3, .m4a, .m4b, .flac, .ogg).",
-    "version": "2.0.12",
+    "version": "2.0.13",
     "keywords": [
         "php",
         "ebook",

--- a/src/Ebook.php
+++ b/src/Ebook.php
@@ -30,6 +30,8 @@ class Ebook
 
     protected ?string $description = null;
 
+    protected ?string $descriptionHtml = null;
+
     protected ?string $publisher = null;
 
     /** @var BookIdentifier[] */
@@ -216,6 +218,7 @@ class Ebook
         $this->authorMain = $ebook->getAuthorMain();
         $this->authors = $ebook->getAuthors();
         $this->description = $ebook->getDescription();
+        $this->descriptionHtml = $ebook->getDescriptionHtml();
         $this->publisher = $ebook->getPublisher();
         $this->identifiers = $ebook->getIdentifiers();
         $this->publishDate = $ebook->getPublishDate();
@@ -303,6 +306,14 @@ class Ebook
         }
 
         return $this->description;
+    }
+
+    /**
+     * Description of the book with HTML sanitized.
+     */
+    public function getDescriptionHtml(): ?string
+    {
+        return $this->descriptionHtml;
     }
 
     /**
@@ -601,6 +612,13 @@ class Ebook
         return $this;
     }
 
+    public function setDescriptionHtml(?string $descriptionHtml): self
+    {
+        $this->descriptionHtml = $descriptionHtml;
+
+        return $this;
+    }
+
     public function setPublisher(?string $publisher): self
     {
         $this->publisher = $publisher;
@@ -705,6 +723,7 @@ class Ebook
             'authorMain' => $this->authorMain?->getName(),
             'authors' => array_map(fn (BookAuthor $author) => $author->getName(), $this->authors),
             'description' => $this->description,
+            'descriptionHtml' => $this->descriptionHtml,
             'publisher' => $this->publisher,
             'identifiers' => array_map(fn (BookIdentifier $identifier) => $identifier->toArray(), $this->identifiers),
             'date' => $this->publishDate?->format('Y-m-d H:i:s'),

--- a/src/Ebook.php
+++ b/src/Ebook.php
@@ -68,6 +68,7 @@ class Ebook
     protected function __construct(
         protected string $path,
         protected string $filename,
+        protected string $basename,
         protected string $extension,
         protected ?BaseArchive $archive = null,
         protected ?Audio $audio = null,
@@ -85,7 +86,46 @@ class Ebook
     public static function read(string $path): ?self
     {
         $start = microtime(true);
-        $filename = pathinfo($path, PATHINFO_BASENAME);
+        $self = self::parseFile($path);
+
+        $format = match ($self->format) {
+            EbookFormatEnum::EPUB => $self->epub(),
+            EbookFormatEnum::MOBI => $self->mobi(),
+            EbookFormatEnum::CBA => $self->cba(),
+            EbookFormatEnum::PDF => $self->pdf(),
+            EbookFormatEnum::AUDIOBOOK => $self->audiobook(),
+            default => null,
+        };
+
+        if ($format === null) {
+            return null;
+        }
+
+        $self->metaTitle = MetaTitle::make($self);
+
+        $time = microtime(true) - $start;
+        $self->execTime = (float) number_format((float) $time, 5, '.', '');
+
+        return $self;
+    }
+
+    /**
+     * Check if an ebook file is valid.
+     */
+    public static function isValid(string $path): bool
+    {
+        $self = self::parseFile($path);
+
+        return ! $self->isBadFile;
+    }
+
+    /**
+     * Parse an ebook file.
+     */
+    private static function parseFile(string $path): Ebook
+    {
+        $basename = pathinfo($path, PATHINFO_BASENAME);
+        $filename = pathinfo($path, PATHINFO_FILENAME);
         $extension = pathinfo($path, PATHINFO_EXTENSION);
 
         $cbaExtensions = ['cbz', 'cbr', 'cb7', 'cbt'];
@@ -102,7 +142,7 @@ class Ebook
             throw new \Exception("Unknown archive type: {$extension}");
         }
 
-        $self = new self($path, $filename, $extension);
+        $self = new self($path, $filename, $basename, $extension);
 
         $self->format = match ($extension) {
             'epub' => $self->format = EbookFormatEnum::EPUB,
@@ -142,24 +182,6 @@ class Ebook
         if ($self->isAudio) {
             $self->audio = Audio::get($path);
         }
-
-        $format = match ($self->format) {
-            EbookFormatEnum::EPUB => $self->epub(),
-            EbookFormatEnum::MOBI => $self->mobi(),
-            EbookFormatEnum::CBA => $self->cba(),
-            EbookFormatEnum::PDF => $self->pdf(),
-            EbookFormatEnum::AUDIOBOOK => $self->audiobook(),
-            default => null,
-        };
-
-        if ($format === null) {
-            return null;
-        }
-
-        $self->metaTitle = MetaTitle::make($self);
-
-        $time = microtime(true) - $start;
-        $self->execTime = (float) number_format((float) $time, 5, '.', '');
 
         return $self;
     }
@@ -298,6 +320,8 @@ class Ebook
 
     /**
      * Description of the book.
+     *
+     * @param  int|null  $limit  Limit the length of the description.
      */
     public function getDescription(int $limit = null): ?string
     {
@@ -310,6 +334,8 @@ class Ebook
 
     /**
      * Description of the book with HTML sanitized.
+     *
+     * If original description doesn't have HTML, it will be the same as `getDescription()`.
      */
     public function getDescriptionHtml(): ?string
     {
@@ -399,7 +425,7 @@ class Ebook
     }
 
     /**
-     * Filename of the ebook.
+     * Filename of the ebook, e.g. `The Clan of the Cave Bear`.
      */
     public function getFilename(): string
     {
@@ -407,7 +433,15 @@ class Ebook
     }
 
     /**
-     * Extension of the ebook.
+     * Basename of the ebook, e.g. `The Clan of the Cave Bear.epub`.
+     */
+    public function getBasename(): string
+    {
+        return $this->basename;
+    }
+
+    /**
+     * Extension of the ebook, e.g. `epub`.
      */
     public function getExtension(): string
     {
@@ -415,15 +449,24 @@ class Ebook
     }
 
     /**
-     * Archive reader.
+     * Archive reader, from `kiwilan/php-archive`.
+     *
+     * @docs https://github.com/kiwilan/php-archive
      */
     public function getArchive(): ?BaseArchive
     {
+        // if (! $this->archive) {
+        //     error_log("{$this->path} can't be read as archive.");
+        //     throw new \Exception("{$this->path} can't be read as archive.");
+        // }
+
         return $this->archive;
     }
 
     /**
-     * Audio reader.
+     * Audio reader, from `kiwilan/php-audio`.
+     *
+     * @docs https://github.com/kiwilan/php-audio
      */
     public function getAudio(): ?Audio
     {
@@ -735,6 +778,7 @@ class Ebook
             'pagesCount' => $this->pagesCount,
             'path' => $this->path,
             'filename' => $this->filename,
+            'basename' => $this->basename,
             'extension' => $this->extension,
             'format' => $this->format,
             'metadata' => $this->metadata?->toArray(),

--- a/src/Ebook.php
+++ b/src/Ebook.php
@@ -319,7 +319,10 @@ class Ebook
     }
 
     /**
-     * Description of the book.
+     * Description of the book, without HTML.
+     *
+     * If original description has HTML, all HTML will be removed and text will be trimmed.
+     * You can use `getDescriptionHtml()` to get the original description sanitized.
      *
      * @param  int|null  $limit  Limit the length of the description.
      */

--- a/src/Formats/EbookModule.php
+++ b/src/Formats/EbookModule.php
@@ -22,6 +22,50 @@ abstract class EbookModule
 
     abstract public function toArray(): array;
 
+    protected function htmlToString(?string $html): ?string
+    {
+        if (! $html) {
+            return null;
+        }
+
+        $html = strip_tags($html);
+        $html = $this->formatText($html);
+
+        return $html;
+    }
+
+    protected function sanitizeHtml(?string $html): ?string
+    {
+        if (! $html) {
+            return null;
+        }
+
+        $html = strip_tags($html, [
+            'div',
+            'p',
+            'br',
+            'b',
+            'i',
+            'u',
+            'strong',
+            'em',
+        ]);
+        $html = $this->formatText($html);
+
+        return $html;
+    }
+
+    private function formatText(string $text): string
+    {
+        $text = str_replace("\n", '', $text);
+        $text = str_replace("\r", '', $text);
+        $text = str_replace("\t", '', $text);
+        $text = trim($text);
+        $text = preg_replace('/\s+/', ' ', $text);
+
+        return $text;
+    }
+
     public function toJson(): string
     {
         return json_encode($this->toArray(), JSON_PRETTY_PRINT);

--- a/src/Formats/EbookModule.php
+++ b/src/Formats/EbookModule.php
@@ -22,6 +22,9 @@ abstract class EbookModule
 
     abstract public function toArray(): array;
 
+    /**
+     * Convert HTML to string, remove all tags.
+     */
     protected function htmlToString(?string $html): ?string
     {
         if (! $html) {
@@ -34,6 +37,9 @@ abstract class EbookModule
         return $html;
     }
 
+    /**
+     * Sanitize HTML, remove all tags except div, p, br, b, i, u, strong, em.
+     */
     protected function sanitizeHtml(?string $html): ?string
     {
         if (! $html) {
@@ -55,6 +61,9 @@ abstract class EbookModule
         return $html;
     }
 
+    /**
+     * Clean string, remove tabs, new lines, carriage returns, and multiple spaces.
+     */
     private function formatText(string $text): string
     {
         $text = str_replace("\n", '', $text);

--- a/src/Formats/Epub/EpubMetadata.php
+++ b/src/Formats/Epub/EpubMetadata.php
@@ -75,9 +75,8 @@ class EpubMetadata extends EbookModule
 
         $authors = array_values($this->opf->getDcCreators());
         $this->ebook->setAuthors($authors);
-        if ($this->opf->getDcDescription()) {
-            $this->ebook->setDescription(strip_tags($this->opf->getDcDescription()));
-        }
+        $this->ebook->setDescription($this->htmlToString($this->opf->getDcDescription()));
+        $this->ebook->setDescriptionHtml($this->sanitizeHtml($this->opf->getDcDescription()));
         $this->ebook->setCopyright(! empty($this->opf->getDcRights()) ? implode(', ', $this->opf->getDcRights()) : null);
         $this->ebook->setPublisher($this->opf->getDcPublisher());
         $this->ebook->setIdentifiers($this->opf->getDcIdentifiers());
@@ -97,14 +96,14 @@ class EpubMetadata extends EbookModule
         $rating = null;
         if (! empty($this->opf->getMeta())) {
             foreach ($this->opf->getMeta() as $meta) {
-                if ($meta->name() === 'calibre:series') {
-                    $this->ebook->setSeries($meta->content());
+                if ($meta->getName() === 'calibre:series') {
+                    $this->ebook->setSeries($meta->getContent());
                 }
-                if ($meta->name() === 'calibre:series_index') {
-                    $this->ebook->setVolume((int) $meta->content());
+                if ($meta->getName() === 'calibre:series_index') {
+                    $this->ebook->setVolume((int) $meta->getContent());
                 }
-                if ($meta->name() === 'calibre:rating') {
-                    $rating = (float) $meta->content();
+                if ($meta->getName() === 'calibre:rating') {
+                    $rating = (float) $meta->getContent();
                 }
             }
         }

--- a/src/Formats/Epub/OpfMetadata.php
+++ b/src/Formats/Epub/OpfMetadata.php
@@ -384,6 +384,10 @@ class OpfMetadata
 
         foreach ($core as $item) {
             $name = XmlReader::parseContent($item);
+            // if `<dc:creator></dc:creator>`
+            if (is_array($name)) {
+                continue;
+            }
             $attributes = XmlReader::parseAttributes($item);
             $items[$name] = new BookAuthor(
                 name: $name,

--- a/src/Tools/BookMeta.php
+++ b/src/Tools/BookMeta.php
@@ -10,12 +10,12 @@ class BookMeta
     ) {
     }
 
-    public function name(): ?string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function content(): ?string
+    public function getContent(): ?string
     {
         return $this->content;
     }

--- a/tests/EbookTest.php
+++ b/tests/EbookTest.php
@@ -56,3 +56,10 @@ it('can parse metadata', function (string $path) {
         expect($metadata->getAudiobook())->toBeInstanceOf(AudiobookMetadata::class);
     }
 })->with([EPUB, CBZ, PDF, AUDIOBOOK]);
+
+it('can have description with HTML', function (string $path) {
+    $ebook = Ebook::read($path);
+
+    expect($ebook->getDescription())->toBe('A natural disaster leaves the young girl wandering alone in an unfamiliar and dangerous land until she is found by a woman of the Clan, people very different from her own kind. To them, blond, blue-eyed Ayla looks peculiar and ugly—she is one of the Others, those who have moved into their ancient homeland; but Iza cannot leave the girl to die and takes her with them. Iza and Creb, the old Mog-ur, grow to love her, and as Ayla learns the ways of the Clan and Iza’s way of healing, most come to accept her. But the brutal and proud youth who is destined to become their next leader sees her differences as a threat to his authority. He develops a deep and abiding hatred for the strange girl of the Others who lives in their midst, and is determined to get his revenge.');
+    expect($ebook->getDescriptionHtml())->toBe('<div> <p>A natural disaster leaves the young girl wandering alone in an unfamiliar and dangerous land until she is found by a woman of the Clan, people very different from her own kind. To them, blond, blue-eyed Ayla looks peculiar and ugly—she is one of the Others, those who have moved into their ancient homeland; but Iza cannot leave the girl to die and takes her with them. Iza and Creb, the old Mog-ur, grow to love her, and as Ayla learns the ways of the Clan and Iza’s way of healing, most come to accept her. But the brutal and proud youth who is destined to become their next leader sees her differences as a threat to his authority. He develops a deep and abiding hatred for the strange girl of the Others who lives in their midst, and is determined to get his revenge.</p></div>');
+})->with([EPUB]);

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -143,8 +143,8 @@ it('can use BookIdentifier', function (string $value, string $scheme) {
 it('can use BookMeta', function (string $name, string $content) {
     $item = new BookMeta($name, $content);
 
-    expect($item->name())->toBe($name);
-    expect($item->content())->toBe($content);
+    expect($item->getName())->toBe($name);
+    expect($item->getContent())->toBe($content);
     expect($item->toArray())->toBe([
         'name' => $name,
         'content' => $content,

--- a/tests/EpubOpfTest.php
+++ b/tests/EpubOpfTest.php
@@ -83,3 +83,23 @@ it('can parse epub opf without tags', function () {
     expect($opf->getCoverPath())->toBeString();
     expect($opf->getEpubVersion())->toBeGreaterThanOrEqual(2);
 });
+
+it('can parse epub opf without author', function (string $path) {
+    $opf = OpfMetadata::make(file_get_contents($path), $path);
+    ray($opf);
+
+    // expect($opf)->tobeInstanceOf(OpfMetadata::class);
+    // expect($path)->toBeReadableFile();
+    // expect($opf->getDcTitle())->toBeString();
+    // expect($opf->getDcCreators())->toBeArray();
+    // expect($opf->getDcDescription())->toBeString();
+    // expect($opf->getDcContributors())->toBeArray();
+    // expect($opf->getDcRights())->toBeArray();
+    // expect($opf->getDcPublisher())->toBeString();
+    // expect($opf->getDcIdentifiers())->toBeArray();
+    // expect($opf->getDcSubject())->toBeArray();
+    // expect($opf->getDcLanguage())->toBeString();
+    // expect($opf->getMeta())->toBeArray();
+    // expect($opf->getCoverPath())->toBeString();
+    // expect($opf->getEpubVersion())->toBeGreaterThanOrEqual(2);
+})->with([EPUB_OPF_EPUB2_NO_TAGS]);

--- a/tests/EpubOpfTest.php
+++ b/tests/EpubOpfTest.php
@@ -84,22 +84,8 @@ it('can parse epub opf without tags', function () {
     expect($opf->getEpubVersion())->toBeGreaterThanOrEqual(2);
 });
 
-it('can parse epub opf without author', function (string $path) {
+it('can parse epub opf with empty dc:creator', function (string $path) {
     $opf = OpfMetadata::make(file_get_contents($path), $path);
-    ray($opf);
 
-    // expect($opf)->tobeInstanceOf(OpfMetadata::class);
-    // expect($path)->toBeReadableFile();
-    // expect($opf->getDcTitle())->toBeString();
-    // expect($opf->getDcCreators())->toBeArray();
-    // expect($opf->getDcDescription())->toBeString();
-    // expect($opf->getDcContributors())->toBeArray();
-    // expect($opf->getDcRights())->toBeArray();
-    // expect($opf->getDcPublisher())->toBeString();
-    // expect($opf->getDcIdentifiers())->toBeArray();
-    // expect($opf->getDcSubject())->toBeArray();
-    // expect($opf->getDcLanguage())->toBeString();
-    // expect($opf->getMeta())->toBeArray();
-    // expect($opf->getCoverPath())->toBeString();
-    // expect($opf->getEpubVersion())->toBeGreaterThanOrEqual(2);
-})->with([EPUB_OPF_EPUB2_NO_TAGS]);
+    expect($opf->getDcCreators())->toBeEmpty();
+})->with([EPUB_OPF_EMPTY_CREATOR]);

--- a/tests/EpubTest.php
+++ b/tests/EpubTest.php
@@ -10,10 +10,12 @@ use Kiwilan\Ebook\Formats\Epub\OpfMetadata;
 it('can parse epub entity', function () {
     $ebook = Ebook::read(EPUB);
     $firstAuthor = $ebook->getAuthors()[0];
+    $filename = pathinfo(EPUB, PATHINFO_FILENAME);
     $basename = pathinfo(EPUB, PATHINFO_BASENAME);
 
     expect($ebook->getpath())->toBe(EPUB);
-    expect($ebook->getFilename())->toBe($basename);
+    expect($ebook->getFilename())->toBe($filename);
+    expect($ebook->getBasename())->toBe($basename);
     expect($ebook->hasMetadata())->toBeTrue();
 
     expect($ebook)->toBeInstanceOf(Ebook::class);
@@ -47,6 +49,7 @@ it('can parse epub entity', function () {
     $metadata = $ebook->getMetadata();
     expect($metadata->toArray())->toBeArray();
     expect($metadata->toJson())->toBeString();
+    expect(Ebook::isValid(EPUB))->toBeTrue();
 });
 
 it('can get epub cover', function () {
@@ -160,8 +163,11 @@ it('can parse epub without tags', function () {
 it('can handle bad file', function () {
     $ebook = Ebook::read(EPUB_BAD_FILE);
 
+    expect(Ebook::isValid(EPUB_BAD_FILE))->toBeFalse();
     expect($ebook->hasMetadata())->toBeFalse();
     expect($ebook->isBadFile())->toBeTrue();
+    // expect(fn () => $ebook->getArchive())->toThrow(Exception::class);
+    expect(fn () => $ebook->getArchive()?->filter('opf'))->not()->toThrow(Exception::class);
 });
 
 it('can handle bad epub', function (string $epub) {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -27,6 +27,7 @@ define('EPUB_OPF_INSURGENT', __DIR__.'/media/opf-insurgent.opf');
 define('EPUB_OPF_LAGUERREETERNELLE', __DIR__.'/media/opf-la-guerre-eternelle.opf');
 define('EPUB_OPF_EPEEETMORT', __DIR__.'/media/opf-content-epee-et-mort.opf');
 define('EPUB_OPF_NOT_FORMATTED', __DIR__.'/media/opf-not-formatted.opf');
+define('EPUB_OPF_EMPTY_CREATOR', __DIR__.'/media/opf-epub2-empty-creator.opf');
 
 define('EPUB', __DIR__.'/media/test-epub.epub');
 define('EPUB_ONE_TAG', __DIR__.'/media/epub-one-tag.epub');

--- a/tests/media/opf-epub2-empty-creator.opf
+++ b/tests/media/opf-epub2-empty-creator.opf
@@ -4,7 +4,7 @@
     xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:calibre="http://calibre.kovidgoyal.net/2009/metadata">
     <dc:title>Le clan de l'ours des cavernes</dc:title>
-    <dc:creator opf:role="aut" opf:file-as="Auel, Jean M.">Jean M. Auel</dc:creator>
+    <dc:creator opf:role="aut" opf:file-as="Auel, Jean M."></dc:creator>
     <dc:contributor opf:role="bkp">calibre (6.12.0) [https://calibre-ebook.com]</dc:contributor>
     <dc:description>&lt;div&gt;
       &lt;p&gt;Quelque part en Europe, 35 000 ans avant notre ère. Petite fille Cro-Magnon de cinq

--- a/tests/media/opf-epub2-no-tags.opf
+++ b/tests/media/opf-epub2-no-tags.opf
@@ -4,7 +4,7 @@
     xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:calibre="http://calibre.kovidgoyal.net/2009/metadata">
     <dc:title>Le clan de l'ours des cavernes</dc:title>
-    <dc:creator opf:role="aut" opf:file-as="Auel, Jean M.">Jean M. Auel</dc:creator>
+    <dc:creator opf:role="aut" opf:file-as="Auel, Jean M."></dc:creator>
     <dc:contributor opf:role="bkp">calibre (6.12.0) [https://calibre-ebook.com]</dc:contributor>
     <dc:description>&lt;div&gt;
       &lt;p&gt;Quelque part en Europe, 35 000 ans avant notre ère. Petite fille Cro-Magnon de cinq


### PR DESCRIPTION
- add `descriptionHtml()` method to `Ebook::class`, which can contains description with html tags if it is available, html is sanitized, original description is still available via `description()` method with plain text
- add `getBasename()` method to `Ebook::class`, which returns basename of ebook file, `getFilename()` now return real filename of ebook file
- add `isValid(string $path)` static method to `Ebook::class`, which checks if ebook file is valid, thanks to @SergioMendolia: <https://github.com/kiwilan/php-ebook/issues/38>
- fix `<dc:creator>` empty tag in `opf` file, thanks to @SergioMendolia: <https://github.com/kiwilan/php-ebook/pull/39>
- Bugfixes