### PR TITLE
Remove deprecation on str_contains

### DIFF
--- a/src/Formats/Pdf/PdfMetadata.php
+++ b/src/Formats/Pdf/PdfMetadata.php
@@ -25,25 +25,27 @@ class PdfMetadata extends EbookModule
         $this->ebook->setTitle($this->meta->getTitle());
 
         $author = $this->meta->getAuthor();
-        $authors = [];
-        if (str_contains($author, ',')) {
-            $authors = explode(',', $author);
-        } elseif (str_contains($author, '&')) {
-            $authors = explode(',', $author);
-        } elseif (str_contains($author, 'and')) {
-            $authors = explode(',', $author);
-        } else {
-            $authors[] = $author;
-        }
+        if($author!==null) {
+            $authors = [];
+            if (str_contains($author, ',')) {
+                $authors = explode(',', $author);
+            } elseif (str_contains($author, '&')) {
+                $authors = explode(',', $author);
+            } elseif (str_contains($author, 'and')) {
+                $authors = explode(',', $author);
+            } else {
+                $authors[] = $author;
+            }
 
-        $creators = [];
-        foreach ($authors as $author) {
-            $creators[] = new BookAuthor(
-                name: trim($author),
-            );
-        }
+            $creators = [];
+            foreach ($authors as $author) {
+                $creators[] = new BookAuthor(
+                    name: trim($author),
+                );
+            }
 
-        $this->ebook->setAuthors($creators);
+            $this->ebook->setAuthors($creators);
+        }
         $this->ebook->setDescription($this->meta->getSubject());
         $this->ebook->setPublisher($this->meta->getCreator());
         $this->ebook->setTags($this->meta->getKeywords());


### PR DESCRIPTION
Fixes
>[2023-08-30T07:59:17.846495+00:00] deprecation.INFO: Deprecated: str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated {"exception":"[object] (ErrorException(code: 0): Deprecated: str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated at /var/www/html/vendor/kiwilan/php-ebook/src/Formats/Pdf/PdfMetadata.php:29)"} []
