### PR TITLE
v2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ PHP package to read metadata and extract covers from eBooks, comics and audioboo
 
 To know more see [Supported formats](#supported-formats). _Supports Linux, macOS and Windows._
 
-> **Note**
+> [!NOTE]
 >
 > This package favors eBooks in open formats such as `.epub` (from [IDPF](https://en.wikipedia.org/wiki/International_Digital_Publishing_Forum)) or `.cbz` (from [CBA](https://en.wikipedia.org/wiki/Comic_book_archive)) and which be parsed with native PHP, so for the best possible experience we recommend converting the eBooks you use. If you want to know more about eBook ecosystem, you can read [documentation](https://github.com/kiwilan/php-ebook/blob/main/docs/README.md).
 
-> **Warning**
+> [!WARNING]
 >
 > For DRM (Digital Rights Management) eBooks, in some cases you could read metadata but not contents (like HTML files for EPUB). To use all features, you have to use a software to remove DRM before using this package. For EPUB, you can use [calibre](https://calibre-ebook.com/) with [DeDRM plugin](https://github.com/noDRM/DeDRM_tools), [this guide](https://www.epubor.com/calibre-drm-removal-plugins.html) can help you.
 
@@ -43,11 +43,11 @@ This package was built for [`bookshelves-project/bookshelves`](https://github.co
     -   [`p7zip`](https://www.7-zip.org/) (optional) binarys for `.CB7` (can handle `.CBR` too)
 -   To know more about requirements, see [Supported formats](#supported-formats).
 
-> **Note**
+> [!NOTE]
 >
 > You have to install requirements only if you want to read metadata for these formats, e.g. if you want to read metadata from `.cbr` files, you have to install [`rar` PHP extension](https://github.com/cataphract/php-rar) or [`p7zip`](https://www.7-zip.org/) binary. So all requirements for PHP extensions and binaries are optional.
 
-> **Warning**
+> [!WARNING]
 >
 > Archives are handle with [`kiwilan/php-archive`](https://github.com/kiwilan/php-archive), for some formats (`.cbr` and `.cb7`) [`rar` PHP extension](https://github.com/cataphract/php-rar) or [`p7zip`](https://www.7-zip.org/) binary could be necessary.
 > Some guides to install these requirements are available on [`kiwilan/php-archive`](https://github.com/kiwilan/php-archive#requirements).
@@ -118,7 +118,7 @@ $ebook->getPagesCount(); // ?int => estimated pages count (250 words by page) in
 $ebook->getWordsCount(); // ?int => words count in `EPUB`
 ```
 
-> **Note**
+> [!NOTE]
 >
 > For performance reasons, with `EPUB`, `pagesCount` and `wordsCount` are only available on demand. If you use `var_dump` to check eBook, these properties will be `null`.
 
@@ -227,7 +227,7 @@ $cover->getPath(); // ?string => path to cover
 $cover->getContents(bool $toBase64 = false); // ?string => content of cover, if `$toBase64` is true, return base64 encoded content
 ```
 
-> **Note**
+> [!NOTE]
 >
 > -   For `PDF`, cover can only be extracted if [`imagick` PHP extension](https://www.php.net/manual/en/book.imagick.php).
 > -   For Audiobook, cover can be extracted with [some formats](https://github.com/kiwilan/php-audio#supported-formats).
@@ -253,7 +253,7 @@ $epub->getHtml(); // EpubHtml[] => {`filename`: string, `head`: ?string, `body`:
 $epub->getFiles(); // string[] => all files in EPUB
 ```
 
-> **Note**
+> [!NOTE]
 >
 > For performance reasons, with `ncx`, `html` and `chapters` are only available on demand. If you use `var_dump` to check metadata, these properties will be `null`.
 
@@ -261,7 +261,7 @@ $epub->getFiles(); // string[] => all files in EPUB
 
 You can create an EPUB or CBZ file with `create()` static method.
 
-> **Note**
+> [!NOTE]
 >
 > Only `EPUB` and `CBZ` are supported for creation.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ PHP package to read metadata and extract covers from eBooks, comics and audioboo
 
 -   eBooks: `.epub`, `.pdf`, `.azw`, `.azw3`, `.kf8`, `.kfx`, `.mobi`, `.prc`, `.fb2`
 -   Comics: `.cbz`, `.cbr`, `.cb7`, `.cbt` (metadata from [github.com/anansi-project](https://github.com/anansi-project))
--   Audiobooks: `.mp3`, `.m4a`, `.m4b`, `.flac`, `.ogg`
+-   Audiobooks: `.mp3`, `.m4a`, `.m4b`, `.flac`, `.ogg` [`kiwilan/php-audio`](https://github.com/kiwilan/php-audio) **MUST** be installed
 
 To know more see [Supported formats](#supported-formats). _Supports Linux, macOS and Windows._
 
@@ -41,7 +41,9 @@ This package was built for [`bookshelves-project/bookshelves`](https://github.co
     -   [`fileinfo`](https://www.php.net/manual/en/book.fileinfo.php) (native, optional) for better detection of file type
 -   **Binaries**
     -   [`p7zip`](https://www.7-zip.org/) (optional) binarys for `.CB7` (can handle `.CBR` too)
--   To know more about requirements, see [Supported formats](#supported-formats).
+-   **Audiobooks**
+    -   [`kiwilan/php-audio`](https://github.com/kiwilan/php-audio) (optional) for `.mp3`, `.m4a`, `.m4b`, `.flac`, `.ogg` (see [Supported formats](#supported-formats)
+-   To know more about requirements, see [Supported formats](#supported-formats)
 
 > [!NOTE]
 >
@@ -57,11 +59,12 @@ This package was built for [`bookshelves-project/bookshelves`](https://github.co
 -   Support multiple formats, see [Supported formats](#supported-formats)
 -   🔎 Read metadata from eBooks, comics, and audiobooks
 -   🖼️ Extract covers from eBooks, comics, and audiobooks
+-   🎵 Works with audiobooks if [`kiwilan/php-audio`](https://github.com/kiwilan/php-audio) is installed
 -   📚 Support metadata
     -   eBooks: `EPUB` v2 and v3 from [IDPF](https://idpf.org/) with `calibre:series` from [Calibre](https://calibre-ebook.com/) | `MOBI` from Mobipocket (and derivatives) | `FB2` from [FictionBook](https://en.wikipedia.org/wiki/FictionBook)
     -   Comics: `CBAM` (Comic Book Archive Metadata) : `ComicInfo.xml` format from _ComicRack_ and maintained by [`anansi-project`](https://github.com/anansi-project/comicinfo)
     -   `PDF` with [`smalot/pdfparser`](https://github.com/smalot/pdfparser)
-    -   Audiobooks: `ID3`, `vorbis` and `flac` tags with [`kiwilan/php-audio`](https://github.com/kiwilan/php-audio)
+    -   Audiobooks: `ID3`, `vorbis` and `flac` tags with [`kiwilan/php-audio`](https://github.com/kiwilan/php-audio) (not included)
 -   🔖 Chapters extraction (`EPUB` only)
 -   📦 `EPUB` and `CBZ` creation supported
 <!-- -   📝 `EPUB` and `CBZ` metadata update supported -->
@@ -86,7 +89,9 @@ composer require kiwilan/php-ebook
 
 ## Usage
 
-With eBook files or audiobook files (to know more about formats, see [Supported formats](#supported-formats)).
+With eBook files or audiobook\* files (to know more about formats, see [Supported formats](#supported-formats)).
+
+\*: should be installed separately, see [Requirements](#requirements).
 
 ```php
 use Kiwilan\Ebook\Ebook;
@@ -234,6 +239,10 @@ $cover->getContents(bool $toBase64 = false); // ?string => content of cover, if 
 
 ### Formats specifications
 
+#### Audiobooks
+
+For audiobooks, you have to install seperately [`kiwilan/php-audio`](https://github.com/kiwilan/php-audio).
+
 #### EPUB
 
 With `EPUB`, metadata are extracted from `OPF` file, `META-INF/container.xml` files, you could access to these metatada but you can also get chapters from `NCX` file. And with `chapters()` method you can merge `NCX` and `HTML` chapters to get full book chapters with `label`, `source` and `content`.
@@ -309,7 +318,7 @@ There is a lot of different formats for eBooks and comics, if you want to know m
 |    Comics CBR    |                 `.cbr`                  |    ✅     | [`rar`](https://github.com/cataphract/php-rar) PHP extension or [`p7zip`](https://www.7-zip.org/) binary |                                     ✅                                      |       ✅       |
 |    Comics CB7    |                 `.cb7`                  |    ✅     |                                 [`p7zip`](https://www.7-zip.org/) binary                                 |                                     ✅                                      |       ✅       |
 |    Comics CBT    |                 `.cbt`                  |    ✅     |                       Native [`phar`](https://www.php.net/manual/en/book.phar.php)                       |                                     ✅                                      |       ✅       |
-|      Audio       | `.mp3`, `.m4a`, `.m4b`, `.flac`, `.ogg` |    ✅     |                     See [`kiwilan/php-audio`](https://github.com/kiwilan/php-audio)                      | [Depends of format](https://github.com/kiwilan/php-audio#supported-formats) |       ❌       |
+|      Audio       | `.mp3`, `.m4a`, `.m4b`, `.flac`, `.ogg` |    ✅     |               If [`kiwilan/php-audio`](https://github.com/kiwilan/php-audio) is installed                | [Depends of format](https://github.com/kiwilan/php-audio#supported-formats) |       ❌       |
 
 ### MOBI cover note
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ PHP package to read metadata and extract covers from eBooks, comics and audioboo
 
 -   eBooks: `.epub`, `.pdf`, `.azw`, `.azw3`, `.kf8`, `.kfx`, `.mobi`, `.prc`, `.fb2`
 -   Comics: `.cbz`, `.cbr`, `.cb7`, `.cbt` (metadata from [github.com/anansi-project](https://github.com/anansi-project))
--   Audiobooks: `.mp3`, `.m4a`, `.m4b`, `.flac`, `.ogg` [`kiwilan/php-audio`](https://github.com/kiwilan/php-audio) **MUST** be installed
+-   Audiobooks: `.mp3`, `.m4a`, `.m4b`, `.flac`, `.ogg` [`kiwilan/php-audio`](https://github.com/kiwilan/php-audio) **MUST** be installed separately
 
 To know more see [Supported formats](#supported-formats). _Supports Linux, macOS and Windows._
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 PHP package to read metadata and extract covers from eBooks, comics and audiobooks.
 
--   eBooks: `.epub`, `.pdf`, `.azw`, `.azw3`, `.kf8`, `.kfx`, `.mobi`, `.prc`
+-   eBooks: `.epub`, `.pdf`, `.azw`, `.azw3`, `.kf8`, `.kfx`, `.mobi`, `.prc`, `.fb2`
 -   Comics: `.cbz`, `.cbr`, `.cb7`, `.cbt` (metadata from [github.com/anansi-project](https://github.com/anansi-project))
 -   Audiobooks: `.mp3`, `.m4a`, `.m4b`, `.flac`, `.ogg`
 
@@ -140,7 +140,7 @@ $isValid = Ebook::isValid('path/to/ebook.epub');
 To get additional data, you can use these methods:
 
 ```php
-$ebook->getMetadata(); // ?EbookMetadata => metadata with parsers
+$ebook->getParser(); // ?EbookParser => Parser with modules
 $ebook->getMetaTitle(); // ?MetaTitle, with slug and sort properties for `title` and `series`
 $ebook->getFormat(); // ?EbookFormatEnum => `epub`, `pdf`, `cba`
 $ebook->getCover(); // ?EbookCover => cover of book
@@ -172,23 +172,23 @@ use Kiwilan\Ebook\Ebook;
 
 $ebook = Ebook::read('path/to/ebook.epub');
 
-$metadata = $ebook->getMetadata();
+$parser = $ebook->getParser();
 
-$metadata->getModule(); // Used into parsing can be any of `EbookModule::class`
+$parser->getModule(); // Used into parsing can be any of `EbookModule::class`
 
-$metadata->getAudiobook(); // `AudiobookModule::class`
-$metadata->getCba(); // `CbaModule::class`
-$metadata->getEpub(); // `EpubModule::class`
-$metadata->getFb2(); // `Fb2Module::class`
-$metadata->getMobi(); // `MobiModule::class`
-$metadata->getPdf(); // `PdfModule::class`
+$parser->getAudiobook(); // `AudiobookModule::class`
+$parser->getCba(); // `CbaModule::class`
+$parser->getEpub(); // `EpubModule::class`
+$parser->getFb2(); // `Fb2Module::class`
+$parser->getMobi(); // `MobiModule::class`
+$parser->getPdf(); // `PdfModule::class`
 
-$metadata->isAudiobook(); // bool
-$metadata->isCba(); // bool
-$metadata->isEpub(); // bool
-$metadata->isFb2(); // bool
-$metadata->isMobi(); // bool
-$metadata->isPdf(); // bool
+$parser->isAudiobook(); // bool
+$parser->isCba(); // bool
+$parser->isEpub(); // bool
+$parser->isFb2(); // bool
+$parser->isMobi(); // bool
+$parser->isPdf(); // bool
 ```
 
 ### MetaTitle
@@ -243,7 +243,7 @@ use Kiwilan\Ebook\Ebook;
 
 $ebook = Ebook::read('path/to/ebook.epub');
 
-$epub = $ebook->getMetadata()?->getEpub();
+$epub = $ebook->getParser()?->getEpub();
 
 $epub->getContainer(); // ?EpubContainer => {`opfPath`: ?string, `version`: ?string, `xml`: array}
 $epub->getOpf(); // ?OpfItem => {`metadata`: array, `manifest`: array, `spine`: array, `guide`: array, `epubVersion`: ?int, `filename`: ?string, `dcTitle`: ?string, `dcCreators`: BookAuthor[], `dcContributors`: BookContributor[], `dcDescription`: ?string, `dcPublisher`: ?string, `dcIdentifiers`: BookIdentifier[], `dcDate`: ?DateTime, `dcSubject`: string[], `dcLanguage`: ?string, `dcRights`: array, `meta`: BookMeta[], `coverPath`: ?string, `contentFile`: string[]}

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kiwilan/php-ebook",
     "description": "PHP package to read metadata and extract covers from eBooks, comics and audiobooks.",
-    "version": "2.2.01",
+    "version": "2.3.0",
     "keywords": [
         "php",
         "ebook",
@@ -40,10 +40,10 @@
     "require": {
         "php": "^8.1",
         "kiwilan/php-archive": "^2.2.0",
-        "kiwilan/php-audio": "^3.0.01",
         "kiwilan/php-xml-reader": "^1.0.11"
     },
     "require-dev": {
+        "kiwilan/php-audio": "^3.0.01",
         "laravel/pint": "^1.7",
         "pestphp/pest": "^1.20",
         "pestphp/pest-plugin-parallel": "^1.2",

--- a/src/Ebook.php
+++ b/src/Ebook.php
@@ -6,7 +6,6 @@ use DateTime;
 use Kiwilan\Archive\Archive;
 use Kiwilan\Archive\ArchiveZipCreate;
 use Kiwilan\Archive\Readers\BaseArchive;
-use Kiwilan\Audio\Audio;
 use Kiwilan\Ebook\Creator\EbookCreator;
 use Kiwilan\Ebook\Enums\EbookFormatEnum;
 use Kiwilan\Ebook\Formats\Audio\AudiobookModule;
@@ -76,7 +75,7 @@ class Ebook
         protected string $basename,
         protected string $extension,
         protected ?BaseArchive $archive = null,
-        protected ?Audio $audio = null,
+        protected ?\Kiwilan\Audio\Audio $audio = null,
         protected bool $isArchive = false,
         protected bool $isAudio = false,
         protected bool $isMobi = false,
@@ -210,7 +209,7 @@ class Ebook
         }
 
         if ($self->isAudio) {
-            $self->audio = Audio::get($path);
+            $self->audio = \Kiwilan\Audio\Audio::get($path);
         }
 
         return $self;
@@ -485,10 +484,11 @@ class Ebook
 
     /**
      * Audio reader, from `kiwilan/php-audio`.
+     * You have to install `kiwilan/php-audio` to use this feature.
      *
      * @docs https://github.com/kiwilan/php-audio
      */
-    public function getAudio(): ?Audio
+    public function getAudio(): ?\Kiwilan\Audio\Audio
     {
         return $this->audio;
     }

--- a/src/Ebook.php
+++ b/src/Ebook.php
@@ -209,6 +209,7 @@ class Ebook
         }
 
         if ($self->isAudio) {
+            AudiobookModule::checkPackage();
             $self->audio = \Kiwilan\Audio\Audio::get($path);
         }
 

--- a/src/EbookCover.php
+++ b/src/EbookCover.php
@@ -47,7 +47,7 @@ class EbookCover
     /**
      * Get the cover contents.
      *
-     * @param  bool  $toBase64 If true, the contents will be returned in base64 format.
+     * @param  bool  $toBase64  If true, the contents will be returned in base64 format.
      */
     public function getContents(bool $toBase64 = false): ?string
     {

--- a/src/Formats/Audio/AudiobookModule.php
+++ b/src/Formats/Audio/AudiobookModule.php
@@ -15,6 +15,10 @@ class AudiobookModule extends EbookModule
 
     public static function make(Ebook $ebook): self
     {
+        if (! \Composer\InstalledVersions::isInstalled('kiwilan/php-audio')) {
+            throw new \Exception('To handle audiobooks, you have to install `kiwilan/php-audio`, see https://github.com/kiwilan/php-audio');
+        }
+
         $self = new self($ebook);
         $self->create();
 

--- a/src/Formats/Audio/AudiobookModule.php
+++ b/src/Formats/Audio/AudiobookModule.php
@@ -15,14 +15,19 @@ class AudiobookModule extends EbookModule
 
     public static function make(Ebook $ebook): self
     {
-        if (! \Composer\InstalledVersions::isInstalled('kiwilan/php-audio')) {
-            throw new \Exception('To handle audiobooks, you have to install `kiwilan/php-audio`, see https://github.com/kiwilan/php-audio');
-        }
+        AudiobookModule::checkPackage();
 
         $self = new self($ebook);
         $self->create();
 
         return $self;
+    }
+
+    public static function checkPackage(): void
+    {
+        if (! \Composer\InstalledVersions::isInstalled('kiwilan/php-audio')) {
+            throw new \Exception('To handle audiobooks, you have to install `kiwilan/php-audio`, see https://github.com/kiwilan/php-audio');
+        }
     }
 
     private function create(): self

--- a/src/Tools/BookIdentifier.php
+++ b/src/Tools/BookIdentifier.php
@@ -5,7 +5,7 @@ namespace Kiwilan\Ebook\Tools;
 class BookIdentifier
 {
     /**
-     * @param  bool  $autoDetect Try to auto detect scheme, even if provided (default: `true`)
+     * @param  bool  $autoDetect  Try to auto detect scheme, even if provided (default: `true`)
      */
     public function __construct(
         protected mixed $value = null,

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -31,7 +31,7 @@ it('can extract pdf cover', function () {
     expect(file_exists($path))->toBeTrue();
     expect($path)->toBeReadableFile();
     expect(fileIsValidImg($path))->toBeTrue();
-})->skip(PHP_OS_FAMILY === 'Windows' || PHP_VERSION > '8.2', 'Skip on Windows');
+})->skip(PHP_OS_FAMILY === 'Windows' || PHP_VERSION >= '8.3', 'Skip on Windows or PHP >= 8.3');
 
 it('can parse empty pdf', function () {
     $ebook = Ebook::read(PDF_EMPTY);


### PR DESCRIPTION
Drop `kiwilan/php-audio` dependency.

Audiobooks are cool, but I suppose many users don't need it. So I think it's better to drop `kiwilan/php-audio` dependency, you have to install `kiwilan/php-audio` manually.
If you scan audiobooks without `kiwilan/php-audio` installed, you will get an error message.
