### PR TITLE
v2.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ PHP package to read metadata and extract covers from eBooks, comics and audioboo
 
 -   eBooks: `.epub`, `.pdf`, `.azw`, `.azw3`, `.kf8`, `.kfx`, `.mobi`, `.prc`, `.fb2`
 -   Comics: `.cbz`, `.cbr`, `.cb7`, `.cbt` (metadata from [github.com/anansi-project](https://github.com/anansi-project))
--   Audiobooks: `.mp3`, `.m4a`, `.m4b`, `.flac`, `.ogg` [`kiwilan/php-audio`](https://github.com/kiwilan/php-audio) **MUST** be installed separately
+-   Audiobooks: `.mp3`, `.m4a`, `.m4b`, `.flac`, `.ogg` with external package[`kiwilan/php-audio`](https://github.com/kiwilan/php-audio) (**MUST** be installed separately)
 
 To know more see [Supported formats](#supported-formats). _Supports Linux, macOS and Windows._
 
@@ -42,7 +42,7 @@ This package was built for [`bookshelves-project/bookshelves`](https://github.co
 -   **Binaries**
     -   [`p7zip`](https://www.7-zip.org/) (optional) binarys for `.CB7` (can handle `.CBR` too)
 -   **Audiobooks**
-    -   [`kiwilan/php-audio`](https://github.com/kiwilan/php-audio) (optional) for `.mp3`, `.m4a`, `.m4b`, `.flac`, `.ogg` (see [Supported formats](#supported-formats)
+    -   [`kiwilan/php-audio`](https://github.com/kiwilan/php-audio) (optional) for `.mp3`, `.m4a`, `.m4b`, `.flac`, `.ogg` (see [Supported formats](#supported-formats))
 -   To know more about requirements, see [Supported formats](#supported-formats)
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ To get additional data, you can use these methods:
 
 ```php
 $ebook->getParser(); // ?EbookParser => Parser with modules
-$ebook->getMetaTitle(); // ?MetaTitle, with slug and sort properties for `title` and `series`
+$ebook->getMetaTitle(); // ?MetaTitle, with slug for `title` and `series`
 $ebook->getFormat(); // ?EbookFormatEnum => `epub`, `pdf`, `cba`
 $ebook->getCover(); // ?EbookCover => cover of book
 ```
@@ -206,16 +206,10 @@ use Kiwilan\Ebook\Ebook;
 $ebook = Ebook::read('path/to/ebook.epub');
 $metaTitle = $ebook->getMetaTitle(); // ?MetaTitle
 
-$metaTitle->getSlug(); // string => slugify title, like `the-clan-of-the-cave-bear`
-$metaTitle->getSlugSort(); // string => slugify title without determiners, like `clan-of-the-cave-bear`
-$metaTitle->getSlugLang(); // string => slugify title with language and type, like `the-clan-of-the-cave-bear-epub-en`
-
-$metaTitle->getSerieSlug(); // ?string => slugify series title, like `earths-children`
-$metaTitle->getSerieSort(); // ?string => slugify series title without determiners, like `earths-children`
-$metaTitle->getSerieLang(); // ?string => slugify series title with language and type, like `earths-children-epub-en`
-
-$metaTitle->getSlugSortWithSerie(); // string => slugify title with series title and volume, like `earths-children-01_clan-of-the-cave-bear`
-$metaTitle->getUniqueFilename(); // string => unique filename for storage, like `jean-m-auel-earths-children-01-clan-of-the-cave-bear-en-epub`
+$metaTitle->getSlug(); // string => slug title, like `pale-lumiere-des-tenebres-a-comme-association-01-1980-pierre-bottero-epub-fr`
+$metaTitle->getSlugSimple(); // string => slug title simple, like `la-pale-lumiere-des-tenebres`
+$metaTitle->getSeriesSlug(); // ?string => slug series title, like `a-comme-association-1980-pierre-bottero-epub-fr`
+$metaTitle->getSeriesSlugSimple(); // ?string => slug series title simple, like `a-comme-association`
 ```
 
 ### Cover
@@ -338,6 +332,7 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed re
 
 -   [`spatie`](https://github.com/spatie) for `spatie/package-skeleton-php`
 -   [`kiwilan`](https://github.com/kiwilan) for `kiwilan/php-archive`, `kiwilan/php-audio`, `kiwilan/php-xml-reader`
+-   [Ewilan Rivière](https://github.com/ewilan-riviere) author of this package
 -   [All Contributors](../../contributors)
 
 ## License

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kiwilan/php-ebook",
     "description": "PHP package to read metadata and extract covers from eBooks, comics and audiobooks.",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "keywords": [
         "php",
         "ebook",

--- a/src/Formats/Audio/AudiobookModule.php
+++ b/src/Formats/Audio/AudiobookModule.php
@@ -83,7 +83,6 @@ class AudiobookModule extends EbookModule
         $this->ebook->setPublisher($audio->getAlbumArtist());
         $this->ebook->setDescription($description);
         $this->ebook->setTags([$audio->getGenre()]);
-        // $this->ebook->setLanguage($audio->getLanguage());
         $this->ebook->setSeries($audio->getAlbum());
         $this->ebook->setVolume($audio->getTrackNumber());
         $this->ebook->setPublishDate($date);

--- a/src/Tools/MetaTitle.php
+++ b/src/Tools/MetaTitle.php
@@ -60,7 +60,6 @@ class MetaTitle
         $extension = strtolower($ebook->getExtension());
 
         $titleDeterminer = $this->removeDeterminers($ebook->getTitle(), $ebook->getLanguage());
-        $seriesDeterminer = $this->removeDeterminers($ebook->getSeries(), $ebook->getLanguage());
 
         if (! $title) {
             return $this;
@@ -76,6 +75,12 @@ class MetaTitle
             $language,
         ]);
         $this->slugSimple = $this->generateSlug([$title]);
+
+        if (! $ebook->getSeries()) {
+            return $this;
+        }
+
+        $seriesDeterminer = $this->removeDeterminers($ebook->getSeries(), $ebook->getLanguage());
 
         $this->seriesSlug = $this->generateSlug([
             $seriesDeterminer,

--- a/src/Tools/MetaTitle.php
+++ b/src/Tools/MetaTitle.php
@@ -12,15 +12,9 @@ class MetaTitle
 
     protected function __construct(
         protected ?string $slug = null,
-        protected ?string $slugSort = null,
-        protected ?string $slugLang = null,
-
-        protected ?string $serieSlug = null,
-        protected ?string $serieSlugSort = null,
-        protected ?string $serieSlugLang = null,
-
-        protected ?string $slugSortWithSerie = null,
-        protected ?string $uniqueFilename = null,
+        protected ?string $slugSimple = null,
+        protected ?string $seriesSlug = null,
+        protected ?string $seriesSlugSimple = null,
     ) {
     }
 
@@ -50,42 +44,60 @@ class MetaTitle
         $self = new self();
 
         $self->determiners = $determiners;
-        $self->setMetaTitle($ebook);
+        $self->parse($ebook);
 
         return $self;
     }
 
-    private function setMetaTitle(Ebook $ebook): static
+    private function parse(Ebook $ebook): static
     {
-        $title = $ebook->getTitle();
-        $language = $ebook->getLanguage();
-        $series = $ebook->getSeries();
-        $volume = $ebook->getVolume();
+        $title = $this->generateSlug($ebook->getTitle());
+        $language = $ebook->getLanguage() ? $this->generateSlug($ebook->getLanguage()) : null;
+        $series = $ebook->getSeries() ? $this->generateSlug($ebook->getSeries()) : null;
+        $volume = $ebook->getVolume() ? str_pad((string) $ebook->getVolume(), 2, '0', STR_PAD_LEFT) : null;
+        $author = $ebook->getAuthorMain()?->getName() ? $this->generateSlug($ebook->getAuthorMain()->getName()) : null;
+        $year = $ebook->getPublishDate()?->format('Y') ? $this->generateSlug($ebook->getPublishDate()->format('Y')) : null;
+        $extension = strtolower($ebook->getExtension());
+
+        $titleDeterminer = $this->removeDeterminers($ebook->getTitle(), $ebook->getLanguage());
+        $seriesDeterminer = $this->removeDeterminers($ebook->getSeries(), $ebook->getLanguage());
 
         if (! $title) {
             return $this;
         }
 
-        $this->slug = $this->setSlug($title);
-        $this->slugSort = $this->generateSortTitle($title, $language);
-        $this->slugLang = $this->generateSlug($title, $ebook->getExtension(), $language);
+        $this->slug = $this->generateSlug([
+            $titleDeterminer,
+            $series,
+            $volume,
+            $year,
+            $author,
+            $extension,
+            $language,
+        ]);
+        $this->slugSimple = $this->generateSlug([$title]);
 
-        $this->slugSortWithSerie = $this->generateSortSerie($title, $series, $volume, $language);
-        $this->uniqueFilename = $this->generateUniqueFilename($ebook);
-
-        if (! $series) {
-            return $this;
-        }
-
-        $this->serieSlug = $this->setSlug($series);
-        $this->serieSlugSort = $this->generateSortTitle($series, $language);
-        $this->serieSlugLang = $this->generateSlug($series, $ebook->getExtension(), $language);
+        $this->seriesSlug = $this->generateSlug([
+            $seriesDeterminer,
+            $year,
+            $author,
+            $extension,
+            $language,
+        ]);
+        $this->seriesSlugSimple = $this->generateSlug([$seriesDeterminer]);
 
         return $this;
     }
 
     /**
-     * Get slug of book title, like `the-clan-of-the-cave-bear`.
+     * Get slug of book title with addional metadata, like `pale-lumiere-des-tenebres-a-comme-association-01-pierre-bottero-epub-fr`.
+     *
+     * - Remove determiners, here `la`
+     * - Add serie title, here `A comme Association`
+     * - Add volume, here `1`
+     * - Add author name, here `Pierre Bottero`
+     * - Add extension, here `epub`
+     * - Add language, here `fr`
      */
     public function getSlug(): string
     {
@@ -93,73 +105,96 @@ class MetaTitle
     }
 
     /**
-     * Get slug of book title without determiners, like `clan-of-the-cave-bear`.
+     * Get simple slug of book title, like `la-pale-lumiere-des-tenebres`.
+     */
+    public function getSlugSimple(): string
+    {
+        return $this->slugSimple;
+    }
+
+    /**
+     * Get slug of serie title, like `a-comme-association-pierre-bottero-epub-fr`.
+     *
+     * - Remove determiners
+     * - Add author name
+     * - Add extension
+     * - Add language
+     */
+    public function getSeriesSlug(): ?string
+    {
+        return $this->seriesSlug;
+    }
+
+    /**
+     * Get simple slug of serie title, like `a-comme-association`.
+     */
+    public function getSeriesSlugSimple(): ?string
+    {
+        return $this->seriesSlugSimple;
+    }
+
+    /**
+     * @deprecated Use `getSlug()` instead.
      */
     public function getSlugSort(): string
     {
-        return $this->slugSort;
+        return $this->slug;
     }
 
     /**
-     * Get slug of book title with language and with type, like `the-clan-of-the-cave-bear-epub-en`.
+     * @deprecated Use `getSlug()` instead.
      */
-    public function getSlugLang(): string
+    public function getSlugUnique(): string
     {
-        return $this->slugLang;
+        return $this->slug;
     }
 
     /**
-     * Get slug of serie title, like `earths-children`.
+     * @deprecated Use `getSeriesSlugSimple()` instead.
      */
     public function getSerieSlug(): ?string
     {
-        return $this->serieSlug;
+        return $this->seriesSlugSimple;
     }
 
     /**
-     * Get slug of serie title without determiners, like `earths-children`.
+     * @deprecated Use `getSeriesSlug()` instead.
      */
     public function getSerieSlugSort(): ?string
     {
-        return $this->serieSlugSort;
+        return $this->seriesSlug;
     }
 
     /**
-     * Get slug of serie title with language and with type, like `earths-children-epub-en`.
+     * @deprecated Use `getSeriesSlug()` instead.
      */
-    public function getSerieSlugLang(): ?string
+    public function getSerieSlugUnique(): ?string
     {
-        return $this->serieSlugLang;
+        return $this->seriesSlug;
     }
 
     /**
-     * Get slug of book title with serie title, like `earths-children-01_clan-of-the-cave-bear`.
-     * If series is null, book's title will be used like `clan-of-the-cave-bear`.
+     * @deprecated Use `getSlug()` instead.
      */
     public function getSlugSortWithSerie(): string
     {
-        return $this->slugSortWithSerie;
+        return $this->slug;
     }
 
     /**
-     * Get unique filename, like `jean-m-auel-earths-children-01-clan-of-the-cave-bear-en-epub`.
+     * @deprecated Use `getSlug()` instead.
      */
     public function getUniqueFilename(): string
     {
-        return $this->uniqueFilename;
+        return $this->slug;
     }
 
-    /**
-     * Try to get sort title.
-     * Example: `collier-de-la-reine` from `Le Collier de la Reine`.
-     */
-    private function generateSortTitle(?string $title, ?string $language): ?string
+    private function removeDeterminers(?string $string, ?string $language): ?string
     {
-        if (! $title) {
+        if (! $string) {
             return null;
         }
 
-        $slugSort = $title;
         $articles = $this->determiners;
 
         $articlesLang = $articles['en'];
@@ -169,93 +204,49 @@ class MetaTitle
         }
 
         foreach ($articlesLang as $key => $value) {
-            $slugSort = preg_replace('/^'.preg_quote($value, '/').'/i', '', $slugSort);
+            $string = preg_replace('/^'.preg_quote($value, '/').'/i', '', $string);
         }
 
-        $transliterator = Transliterator::createFromRules(':: Any-Latin; :: Latin-ASCII; :: NFD; :: [:Nonspacing Mark:] Remove; :: Lower(); :: NFC;', Transliterator::FORWARD);
-        $slugSort = $transliterator->transliterate($slugSort);
-        $slugSort = strtolower($slugSort);
-
-        return $this->setSlug(mb_convert_encoding($slugSort, 'UTF-8'));
+        return $string;
     }
 
     /**
-     * Generate full title sort.
-     * Example: `miserables-01_fantine` from `Les Misérables, volume 01 : Fantine`.
+     * Generate `slug` with params.
+     *
+     * @param  string[]|null[]|string  $strings
      */
-    private function generateSortSerie(string $title, ?string $serieTitle, ?int $volume, ?string $language): string
+    private function generateSlug(array|string $strings): ?string
     {
-        $serie = null;
-
-        if ($serieTitle) {
-            $volume = (string) $volume;
-            $volume = strlen($volume) < 2 ? '0'.$volume : $volume;
-            $serie = $serieTitle.' '.$volume;
-            $serie = $this->setSlug($this->generateSortTitle($serie, $language)).'_';
+        if (! is_array($strings)) {
+            $strings = [$strings];
         }
-        $title = $this->setSlug($this->generateSortTitle($title, $language));
 
-        return "{$serie}{$title}";
-    }
+        $items = [];
 
-    /**
-     * Generate `slug` with `title`, `type` and `language`.
-     */
-    private function generateSlug(string $title, ?string $type, ?string $language): string
-    {
-        $title = $this->setSlug($title);
-        $type = $this->setSlug($type);
-        $language = $this->setSlug($language);
+        foreach ($strings as $string) {
+            if (! $string) {
+                continue;
+            }
 
-        return $this->setSlug($title.' '.$type.' '.$language);
-    }
-
-    /**
-     * Generate unique filename.
-     */
-    private function generateUniqueFilename(Ebook $ebook): string
-    {
-        $language = $this->setSlug($ebook->getLanguage());
-        $filename = "{$language}";
-        if ($ebook->getSeries()) {
-            $series = $this->setSlug($ebook->getSeries());
-            $filename .= "-{$series}";
+            $items[] = $this->slugifier($string);
         }
-        if ($ebook->getVolume()) {
-            $volume = (string) $ebook->getVolume();
-            $volume = $volume = strlen($volume) < 2 ? '0'.$volume : $volume;
-            $filename .= "-{$volume}";
-        }
-        $title = $this->setSlug($ebook->getTitle());
-        $filename .= "-{$title}";
-        $author = $this->setSlug($ebook->getAuthorMain());
-        $filename .= "-{$author}";
-        $format = $this->setSlug($ebook->getExtension());
-        $filename .= "-{$format}";
 
-        $filename = $this->setSlug($filename);
-
-        return $filename;
+        return $this->slugifier(implode('-', $items));
     }
 
     public function toArray(): array
     {
         return [
             'slug' => $this->slug,
-            'slugSort' => $this->slugSort,
-            'slugLang' => $this->slugLang,
-
-            'serieSlug' => $this->serieSlug,
-            'serieSlugSort' => $this->serieSlugSort,
-            'serieSlugLang' => $this->serieSlugLang,
-
-            'slugSortWithSerie' => $this->slugSortWithSerie,
+            'slugSimple' => $this->slugSimple,
+            'seriesSlug' => $this->seriesSlug,
+            'seriesSlugSimple' => $this->seriesSlugSimple,
         ];
     }
 
     public function __toString(): string
     {
-        return "{$this->slug} {$this->slugSort}";
+        return "{$this->slug}";
     }
 
     /**
@@ -264,14 +255,14 @@ class MetaTitle
      *
      * @param  array<string, string>  $dictionary
      */
-    private function setSlug(?string $title, string $separator = '-', array $dictionary = ['@' => 'at']): ?string
+    private function slugifier(?string $title, string $separator = '-', array $dictionary = ['@' => 'at']): ?string
     {
         if (! $title) {
             return null;
         }
 
         if (! extension_loaded('intl')) {
-            return $this->setSlugNoIntl($title, $separator);
+            return $this->slugifierNative($title, $separator);
         }
 
         $transliterator = Transliterator::createFromRules(':: Any-Latin; :: Latin-ASCII; :: NFD; :: [:Nonspacing Mark:] Remove; :: Lower(); :: NFC;', Transliterator::FORWARD);
@@ -298,7 +289,7 @@ class MetaTitle
         return trim($title, $separator);
     }
 
-    private function setSlugNoIntl(?string $text, string $divider = '-'): ?string
+    private function slugifierNative(?string $text, string $divider = '-'): ?string
     {
         if (! $text) {
             return null;

--- a/tests/EpubTest.php
+++ b/tests/EpubTest.php
@@ -68,13 +68,8 @@ it('can get title meta', function () {
     $ebook = Ebook::read(EPUB);
     $meta = $ebook->getMetaTitle();
 
-    expect($meta->getSlug())->toBe('the-clan-of-the-cave-bear');
-    expect($meta->getSlugSort())->toBe('clan-of-the-cave-bear');
-    expect($meta->getSlugLang())->toBe('the-clan-of-the-cave-bear-epub-en');
-    expect($meta->getSerieSlug())->toBe('earths-children');
-    expect($meta->getSerieSlugSort())->toBe('earths-children');
-    expect($meta->getSerieSlugLang())->toBe('earths-children-epub-en');
-    expect($meta->getSlugSortWithSerie())->toBe('earths-children-01_clan-of-the-cave-bear');
+    expect($meta->getSlug())->toBe('clan-of-the-cave-bear-earths-children-01-1980-jean-m-auel-epub-en');
+    expect($meta->getSeriesSlug())->toBe('earths-children-1980-jean-m-auel-epub-en');
 
     expect($meta->toArray())->toBeArray();
     expect($meta->__toString())->toBeString();

--- a/tests/MetaTitleTest.php
+++ b/tests/MetaTitleTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Kiwilan\Ebook\Ebook;
+use Kiwilan\Ebook\Tools\BookAuthor;
 use Kiwilan\Ebook\Tools\MetaTitle;
 
 it('can be slugify', function () {
@@ -10,14 +11,12 @@ it('can be slugify', function () {
     $ebook->setVolume(1);
     $ebook->setSeries('A comme Association');
     $ebook->setLanguage('fr');
+    $ebook->setAuthorMain(new BookAuthor('Pierre Bottero'));
     $meta = MetaTitle::make($ebook);
 
-    expect($meta->getSlug())->toBe('la-pale-lumiere-des-tenebres');
-    expect($meta->getSlugSort())->toBe('pale-lumiere-des-tenebres');
-    expect($meta->getSlugLang())->toBe('la-pale-lumiere-des-tenebres-epub-fr');
-    expect($meta->getSerieSlug())->toBe('a-comme-association');
-    expect($meta->getSerieSlugSort())->toBe('a-comme-association');
-    expect($meta->getSerieSlugLang())->toBe('a-comme-association-epub-fr');
-    expect($meta->getSlugSortWithSerie())->toBe('a-comme-association-01_pale-lumiere-des-tenebres');
-    expect($meta->getUniqueFilename())->toBe('fr-a-comme-association-01-la-pale-lumiere-des-tenebres-jean-m-auel-epub');
+    expect($meta->getSlug())->toBe('pale-lumiere-des-tenebres-a-comme-association-01-1980-pierre-bottero-epub-fr');
+    expect($meta->getSlugSimple())->toBe('la-pale-lumiere-des-tenebres');
+
+    expect($meta->getSeriesSlug())->toBe('a-comme-association-1980-pierre-bottero-epub-fr');
+    expect($meta->getSeriesSlugSimple())->toBe('a-comme-association');
 });


### PR DESCRIPTION
Deprecated some `MetaTitle` methods `getSlugSort()`, `getSlugUnique()`, `getSerieSlug()`, `getSerieSlugSort()`, `getSerieSlugUnique()`, `getSlugSortWithSerie()`, `getUniqueFilename()`. Now only `getSlug()`, `getSlugSimple()`, `getSeriesSlug()`, `getSeriesSlugSimple()` are available.

Slug have to be unique, so default slug take some metadata to be unique, like in this example:

An EPUB with title `La pâle lumière des ténèbres` with main author `Pierre Bottero`, series `A comme Association`, volume `1`, language `fr` and published in `1980` will have the slug `pale-lumiere-des-tenebres-a-comme-association-01-1980-pierre-bottero-epub-fr`.

You can use `getSlugSimple()` to have a simple slug, like `pale-lumiere-des-tenebres`.

For series, you can use `getSeriesSlug()` to have a slug with series name, like `a-comme-association-1980-pierre-bottero-epub-fr`.

And `getSeriesSlugSimple()` to have a simple slug with series name, like `a-comme-association`.
