### PR TITLE
v2.3.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kiwilan/php-ebook",
     "description": "PHP package to read metadata and extract covers from eBooks, comics and audiobooks.",
-    "version": "2.3.6",
+    "version": "2.3.7",
     "keywords": [
         "php",
         "ebook",

--- a/src/Ebook.php
+++ b/src/Ebook.php
@@ -113,7 +113,7 @@ class Ebook
         $self->parser = EbookParser::make($format);
         $self->convertEbook();
         $self->cover = $self->parser->getModule()->toCover();
-        $self->metaTitle = MetaTitle::make($self);
+        $self->metaTitle = MetaTitle::fromEbook($self);
 
         $time = microtime(true) - $start;
         $self->execTime = (float) number_format((float) $time, 5, '.', '');
@@ -739,7 +739,7 @@ class Ebook
             return $this;
         }
 
-        $this->metaTitle = MetaTitle::make($ebook);
+        $this->metaTitle = MetaTitle::fromEbook($ebook);
 
         return $this;
     }

--- a/tests/MetaTitleTest.php
+++ b/tests/MetaTitleTest.php
@@ -12,7 +12,7 @@ it('can be slugify', function () {
     $ebook->setSeries('A comme Association');
     $ebook->setLanguage('fr');
     $ebook->setAuthorMain(new BookAuthor('Pierre Bottero'));
-    $meta = MetaTitle::make($ebook);
+    $meta = MetaTitle::fromEbook($ebook);
 
     expect($meta->getSlug())->toBe('a-comme-association-fr-01-pale-lumiere-des-tenebres-pierre-bottero-1980-epub');
     expect($meta->getSlugSimple())->toBe('la-pale-lumiere-des-tenebres');
@@ -24,7 +24,7 @@ it('can be slugify', function () {
     $ebook->setSeries('The Lord of the Rings');
     $ebook->setLanguage('en');
     $ebook->setAuthorMain(new BookAuthor('J. R. R. Tolkien'));
-    $meta = MetaTitle::make($ebook);
+    $meta = MetaTitle::fromEbook($ebook);
 
     expect($meta->getSlug())->toBe('lord-of-the-rings-en-01-fellowship-of-the-ring-j-r-r-tolkien-1980-epub');
     expect($meta->getSlugSimple())->toBe('the-fellowship-of-the-ring');
@@ -36,10 +36,25 @@ it('can be slugify', function () {
     $ebook->setSeries(null);
     $ebook->setLanguage('en');
     $ebook->setAuthorMain(new BookAuthor('Andy Weir'));
-    $meta = MetaTitle::make($ebook);
+    $meta = MetaTitle::fromEbook($ebook);
 
     expect($meta->getSlug())->toBe('artemis-en-andy-weir-1980-epub');
     expect($meta->getSlugSimple())->toBe('artemis');
     expect($meta->getSeriesSlug())->toBeNull();
     expect($meta->getSeriesSlugSimple())->toBeNull();
+
+    $meta = MetaTitle::fromData(
+        title: 'The Fellowship of the Ring',
+        volume: 1,
+        series: 'The Lord of the Rings',
+        language: 'en',
+        author: 'J. R. R. Tolkien',
+        year: 1980,
+        extension: 'epub',
+    );
+
+    expect($meta->getSlug())->toBe('lord-of-the-rings-en-01-fellowship-of-the-ring-j-r-r-tolkien-1980-epub');
+    expect($meta->getSlugSimple())->toBe('the-fellowship-of-the-ring');
+    expect($meta->getSeriesSlug())->toBe('lord-of-the-rings-en-j-r-r-tolkien-epub');
+    expect($meta->getSeriesSlugSimple())->toBe('the-lord-of-the-rings');
 });


### PR DESCRIPTION
`MetaTitle::class`: add `fromData()` static method to generate a `MetaTitle` object from a raw data and rename `make()` to `fromEbook()`.