### PR TITLE
v2.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kiwilan/php-ebook",
     "description": "PHP package to read metadata and extract covers from eBooks, comics and audiobooks.",
-    "version": "2.4.9",
+    "version": "2.5.0",
     "keywords": [
         "php",
         "ebook",

--- a/src/Models/MetaTitle.php
+++ b/src/Models/MetaTitle.php
@@ -329,7 +329,7 @@ class MetaTitle
         string $title,
         ?string $language = null,
         ?string $series = null,
-        string|int|null $volume = null,
+        string|int|float|null $volume = null,
         ?string $author = null,
         string|int|null $year = null,
         ?string $extension = null,


### PR DESCRIPTION
- `MetaTitle::class`: `fromData()` method `volume` parameter is now `string|int|float|null` instead of `string|int|null`.