### PR TITLE
v2.5.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kiwilan/php-ebook",
     "description": "PHP package to read metadata and extract covers from eBooks, comics and audiobooks.",
-    "version": "2.5.0",
+    "version": "2.5.10",
     "keywords": [
         "php",
         "ebook",

--- a/src/Formats/Audio/AudiobookModule.php
+++ b/src/Formats/Audio/AudiobookModule.php
@@ -37,7 +37,10 @@ class AudiobookModule extends EbookModule
         $audio = $this->ebook->getAudio();
 
         $authors = $audio->getArtist() ?? $audio->getAlbumArtist();
-        $genres = $this->parseGenres($audio->getGenre());
+
+        $genres = EbookUtils::parseStringWithSeperator($audio->getGenre());
+        $genres = array_map('ucfirst', $genres);
+
         $series = $audio->getTag('series') ?? $audio->getTag('mvnm');
         $series_part = $audio->getTag('series-part') ?? $audio->getTag('mvin');
         $series_part = $this->parseTag($series_part);
@@ -51,12 +54,12 @@ class AudiobookModule extends EbookModule
         }
 
         $this->audio = [
-            'authors' => $this->parseAuthors($authors),
+            'authors' => EbookUtils::parseStringWithSeperator($authors),
             'title' => $audio->getAlbum() ?? $audio->getTitle(),
             'subtitle' => $this->parseTag($audio->getTag('subtitle'), false),
             'publisher' => $audio->getTag('encoded_by'),
             'publish_year' => $audio->getYear(),
-            'narrators' => $this->parseAuthors($narrators),
+            'narrators' => EbookUtils::parseStringWithSeperator($narrators),
             'description' => $this->parseTag($audio->getDescription(), false),
             'lyrics' => $this->parseTag($audio->getLyrics()),
             'comment' => $this->parseTag($audio->getComment()),
@@ -184,59 +187,6 @@ class AudiobookModule extends EbookModule
     public function __toString(): string
     {
         return $this->toJson();
-    }
-
-    /**
-     * @return string[]
-     */
-    private function parseGenres(?string $genres): array
-    {
-        if (! $genres) {
-            return [];
-        }
-
-        $items = [];
-        if (str_contains($genres, ';')) {
-            $items = explode(';', $genres);
-        } elseif (str_contains($genres, '/')) {
-            $items = explode('/', $genres);
-        } elseif (str_contains($genres, '//')) {
-            $items = explode('//', $genres);
-        } elseif (str_contains($genres, ',')) {
-            $items = explode(',', $genres);
-        } else {
-            $items = [$genres];
-        }
-
-        $items = array_map('trim', $items);
-        $items = array_map('ucfirst', $items);
-
-        return $items;
-    }
-
-    /**
-     * @return string[]
-     */
-    private function parseAuthors(?string $authors): array
-    {
-        if (! $authors) {
-            return [];
-        }
-
-        $items = [];
-        if (str_contains($authors, ',')) {
-            $items = explode(',', $authors);
-        } elseif (str_contains($authors, ';')) {
-            $items = explode(';', $authors);
-        } elseif (str_contains($authors, '&')) {
-            $items = explode('&', $authors);
-        } elseif (str_contains($authors, 'and')) {
-            $items = explode('and', $authors);
-        } else {
-            $items = [$authors];
-        }
-
-        return array_map('trim', $items);
     }
 
     private function parseTag(?string $tag, bool $flat = true): ?string

--- a/src/Formats/Mobi/MobiModule.php
+++ b/src/Formats/Mobi/MobiModule.php
@@ -10,6 +10,7 @@ use Kiwilan\Ebook\Formats\Mobi\Parser\MobiParser;
 use Kiwilan\Ebook\Formats\Mobi\Parser\MobiReader;
 use Kiwilan\Ebook\Models\BookAuthor;
 use Kiwilan\Ebook\Models\BookIdentifier;
+use Kiwilan\Ebook\Utils\EbookUtils;
 
 /**
  * @docs https://stackoverflow.com/questions/11817047/php-library-to-parse-mobi
@@ -33,7 +34,13 @@ class MobiModule extends EbookModule
             return $this->ebook;
         }
 
+        $authors = [];
         foreach ($this->parser->get(MobiReader::AUTHOR_100, true) as $author) {
+            $authors[] = $author;
+        }
+
+        $authors = EbookUtils::parseStringWithSeperator($authors);
+        foreach ($authors as $author) {
             $this->ebook->setAuthor(new BookAuthor($author));
         }
 

--- a/src/Formats/Pdf/PdfModule.php
+++ b/src/Formats/Pdf/PdfModule.php
@@ -7,6 +7,7 @@ use Kiwilan\Ebook\Ebook;
 use Kiwilan\Ebook\EbookCover;
 use Kiwilan\Ebook\Formats\EbookModule;
 use Kiwilan\Ebook\Models\BookAuthor;
+use Kiwilan\Ebook\Utils\EbookUtils;
 
 class PdfModule extends EbookModule
 {
@@ -27,16 +28,7 @@ class PdfModule extends EbookModule
         $author = $this->meta?->getAuthor();
 
         if ($author !== null) {
-            $authors = [];
-            if (str_contains($author, ',')) {
-                $authors = explode(',', $author);
-            } elseif (str_contains($author, '&')) {
-                $authors = explode(',', $author);
-            } elseif (str_contains($author, 'and')) {
-                $authors = explode(',', $author);
-            } else {
-                $authors[] = $author;
-            }
+            $authors = EbookUtils::parseStringWithSeperator($author);
 
             $creators = [];
             foreach ($authors as $author) {
@@ -49,9 +41,9 @@ class PdfModule extends EbookModule
         }
         $this->ebook->setDescription($this->meta?->getSubject());
         $this->ebook->setPublisher($this->meta?->getCreator());
-        $this->ebook->setTags($this->meta?->getKeywords());
+        $keywords = EbookUtils::parseStringWithSeperator($this->meta?->getKeywords());
+        $this->ebook->setTags($keywords);
         $this->ebook->setPublishDate($this->meta?->getCreationDate());
-
         $this->ebook->setHasParser(true);
 
         return $this->ebook;

--- a/src/Utils/EbookUtils.php
+++ b/src/Utils/EbookUtils.php
@@ -4,6 +4,42 @@ namespace Kiwilan\Ebook\Utils;
 
 class EbookUtils
 {
+    /**
+     * @return string[]|null|string|int
+     */
+    public static function parseStringWithSeperator(mixed $content): mixed
+    {
+        if (! $content) {
+            return null;
+        }
+
+        if (! is_string($content)) {
+            return $content;
+        }
+
+        if (str_contains($content, ',')) {
+            $content = explode(',', $content);
+        } elseif (str_contains($content, ';')) {
+            $content = explode(';', $content);
+        } elseif (str_contains($content, '&')) {
+            $content = explode('&', $content);
+        } elseif (str_contains($content, 'and')) {
+            $content = explode('and', $content);
+        } elseif (str_contains($content, '/')) {
+            $content = explode('/', $content);
+        } elseif (str_contains($content, '//')) {
+            $content = explode('//', $content);
+        } else {
+            $content = [$content];
+        }
+
+        if (is_array($content)) {
+            $content = array_map('trim', $content);
+        }
+
+        return $content;
+    }
+
     public static function parseNumber(mixed $number): int|float|null
     {
         if (EbookUtils::isFloat($number)) {

--- a/tests/EpubTest.php
+++ b/tests/EpubTest.php
@@ -71,7 +71,7 @@ it('can get title meta', function () {
     $ebook = Ebook::read(EPUB);
     $meta = $ebook->getMetaTitle();
 
-    expect($meta->getSlug())->toBe('earths-children-en-01-clan-of-the-cave-bear-jean-m-auel-1980-epub');
+    expect($meta->getSlug())->toBe('earths-children-en-001-clan-of-the-cave-bear-jean-m-auel-1980-epub');
     expect($meta->getSeriesSlug())->toBe('earths-children-en-jean-m-auel-epub');
 
     expect($meta->toArray())->toBeArray();
@@ -194,6 +194,7 @@ it('can parse epub with series and float volume', function (string $path) {
     $ebook = Ebook::read($path);
 
     expect($ebook->getVolume())->toBe(1.5);
+    expect($ebook->getMetaTitle()?->getSlug())->toBe('enfants-de-la-terre-fr-001.5-clan-de-lours-des-cavernes-jean-m-auel-1980-epub');
 })->with([EPUB_VOLFLOAT]);
 
 it('can parse epub with bad summary', function (string $path) {

--- a/tests/MetaTitleTest.php
+++ b/tests/MetaTitleTest.php
@@ -14,7 +14,7 @@ it('can be slugify', function () {
     $ebook->setAuthorMain(new BookAuthor('Pierre Bottero'));
     $meta = MetaTitle::fromEbook($ebook);
 
-    expect($meta->getSlug())->toBe('a-comme-association-fr-01-pale-lumiere-des-tenebres-pierre-bottero-1980-epub');
+    expect($meta->getSlug())->toBe('a-comme-association-fr-001-pale-lumiere-des-tenebres-pierre-bottero-1980-epub');
     expect($meta->getSlugSimple())->toBe('la-pale-lumiere-des-tenebres');
     expect($meta->getSeriesSlug())->toBe('a-comme-association-fr-pierre-bottero-epub');
     expect($meta->getSeriesSlugSimple())->toBe('a-comme-association');
@@ -26,7 +26,7 @@ it('can be slugify', function () {
     $ebook->setAuthorMain(new BookAuthor('J. R. R. Tolkien'));
     $meta = MetaTitle::fromEbook($ebook);
 
-    expect($meta->getSlug())->toBe('lord-of-the-rings-en-01-fellowship-of-the-ring-j-r-r-tolkien-1980-epub');
+    expect($meta->getSlug())->toBe('lord-of-the-rings-en-001-fellowship-of-the-ring-j-r-r-tolkien-1980-epub');
     expect($meta->getSlugSimple())->toBe('the-fellowship-of-the-ring');
     expect($meta->getSeriesSlug())->toBe('lord-of-the-rings-en-j-r-r-tolkien-epub');
     expect($meta->getSeriesSlugSimple())->toBe('the-lord-of-the-rings');
@@ -53,8 +53,58 @@ it('can be slugify', function () {
         extension: 'epub',
     );
 
-    expect($meta->getSlug())->toBe('lord-of-the-rings-en-01-fellowship-of-the-ring-j-r-r-tolkien-1980-epub');
+    expect($meta->getSlug())->toBe('lord-of-the-rings-en-001-fellowship-of-the-ring-j-r-r-tolkien-1980-epub');
     expect($meta->getSlugSimple())->toBe('the-fellowship-of-the-ring');
     expect($meta->getSeriesSlug())->toBe('lord-of-the-rings-en-j-r-r-tolkien-epub');
     expect($meta->getSeriesSlugSimple())->toBe('the-lord-of-the-rings');
+});
+
+it('can slug without intl', function () {
+    $meta = MetaTitle::fromData(
+        title: 'La pâle lumière des ténèbres',
+        language: 'fr',
+        series: 'A comme Association',
+        volume: 1.5,
+        author: 'Pierre Bottero',
+        extension: 'epub',
+        useIntl: false,
+    );
+
+    expect($meta->getSlug())->toBe('a-comme-association-fr-001.5-pale-lumiere-des-tenebres-pierre-bottero-epub');
+    expect($meta->getSlugSimple())->toBe('la-pale-lumiere-des-tenebres');
+    expect($meta->getSeriesSlug())->toBe('a-comme-association-fr-pierre-bottero-epub');
+    expect($meta->getSeriesSlugSimple())->toBe('a-comme-association');
+});
+
+it('can use alt volume', function () {
+    $ebook = Ebook::read(EPUB_VOLFLOAT);
+    $meta = $ebook->getMetaTitle();
+
+    expect($meta->getSlug())->toBe('enfants-de-la-terre-fr-001.5-clan-de-lours-des-cavernes-jean-m-auel-1980-epub');
+});
+
+it('can use determiner title', function () {
+    $ebook = Ebook::read(EPUB);
+    $ebook->setSeries("L'Assassin Royal");
+    $ebook->setLanguage('fr');
+    $ebook->setAuthorMain(new BookAuthor('Robin Hobb'));
+
+    $ebook->setTitle("L'apprenti assassin");
+    $ebook->setVolume(1);
+    $meta = MetaTitle::fromEbook($ebook);
+
+    expect($meta->getSlug())->toBe('assassin-royal-fr-001-apprenti-assassin-robin-hobb-1980-epub');
+
+    $ebook->setTitle('Le Prince Bâtard');
+    $ebook->setVolume(0);
+    $meta = MetaTitle::fromEbook($ebook);
+
+    expect($meta->getSlug())->toBe('assassin-royal-fr-000-prince-batard-robin-hobb-1980-epub');
+    ray($ebook->toArray());
+
+    $ebook->setTitle("L'apprenti assassin");
+    $ebook->setVolume(50);
+    $meta = MetaTitle::fromEbook($ebook);
+
+    expect($meta->getSlug())->toBe('assassin-royal-fr-050-apprenti-assassin-robin-hobb-1980-epub');
 });

--- a/tests/OpfTest.php
+++ b/tests/OpfTest.php
@@ -137,6 +137,11 @@ it('can parse epub opf with empty dc:creator', function (string $path) {
 })->with([EPUB_OPF_EMPTY_CREATOR]);
 
 it('can use float volume', function () {
-    $opf = OpfItem::make(file_get_contents(EPUB_OPF_EPUB2_VOLUME_FLOAT), EPUB_OPF_EPUB2_VOLUME_FLOAT);
+    $opf = OpfItem::make(file_get_contents(EPUB_OPF_EPUB2_VOLUME_FLOAT));
     expect($opf->getMetaItem('calibre:series_index')->getContents())->toBe('1.5');
 });
+
+it('can use multiple authors', function (string $path) {
+    $opf = OpfItem::make(file_get_contents($path));
+    expect($opf->getDcCreators())->toHaveCount(2);
+})->with([EPUB_OPF_MULTIPLE_AUTHORS, EPUB_OPF_MULTIPLE_AUTHORS_MERGE]);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -34,6 +34,8 @@ define('EPUB_OPF_EPEEETMORT', __DIR__.'/media/opf-content-epee-et-mort.opf');
 define('EPUB_OPF_NOT_FORMATTED', __DIR__.'/media/opf-not-formatted.opf');
 define('EPUB_OPF_EMPTY_CREATOR', __DIR__.'/media/opf-epub2-empty-creator.opf');
 define('EPUB_OPF_LA5EVAGUE', __DIR__.'/media/opf-content-la-5e-vague.opf');
+define('EPUB_OPF_MULTIPLE_AUTHORS', __DIR__.'/media/opf-epub2-multiple-authors.opf');
+define('EPUB_OPF_MULTIPLE_AUTHORS_MERGE', __DIR__.'/media/opf-epub2-multiple-authors-merge.opf');
 
 define('EPUB', __DIR__.'/media/test-epub.epub');
 define('EPUB_ONE_TAG', __DIR__.'/media/epub-one-tag.epub');

--- a/tests/media/opf-epub2-multiple-authors-merge.opf
+++ b/tests/media/opf-epub2-multiple-authors-merge.opf
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0" unique-identifier="uuid_id">
+  <metadata xmlns:opf="http://www.idpf.org/2007/opf" xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:calibre="http://calibre.kovidgoyal.net/2009/metadata">
+    <dc:title>Le clan de l'ours des cavernes</dc:title>
+    <dc:creator opf:role="aut" opf:file-as="Jean M. Auel, Philippe Rouard">Jean M. Auel, Philippe
+      Rouard</dc:creator>
+    <dc:contributor opf:role="bkp">calibre (6.12.0) [https://calibre-ebook.com]</dc:contributor>
+    <dc:description>&lt;div&gt;
+      &lt;p&gt;Quelque part en Europe, 35 000 ans avant notre ère. Petite fille Cro-Magnon de cinq
+      ans, Ayla est séparée de ses parents à la suite d'un violent tremblement de terre. Elle est
+      recueillie par le clan de l'ours des cavernes, une tribu Neandertal qui l'adopte, non sans
+      réticence, ayant reconnu en elle la représentante d'une autre espèce, plus évoluée.
+      &lt;br&gt;&lt;br&gt;Iza, la guérisseuse, Brun, le chef et Creb, le magicien lui enseignent les
+      règles de la vie communautaire, leurs rites, leurs peurs, leurs audaces. Mais Ayla, la
+      fillette blonde aux yeux bleus les surprend par sa puissance de raisonnement qui lui permet de
+      s'adapter, de réagir rapidement et de ne pas être totalement dépendante de son environnement.
+      Une différence qui ne tarde pas à faire d'elle une menace pour tout le clan, et à attiser la
+      convoitise de Brud, le fils du chef...&lt;/p&gt;&lt;/div&gt;</dc:description>
+    <dc:publisher>Presses de la cité</dc:publisher>
+    <dc:identifier id="uuid_id" opf:scheme="uuid">a2cf2f25-4de2-4f77-82cc-0198352b0851</dc:identifier>
+    <dc:date>1980-01-13T21:00:00+00:00</dc:date>
+    <dc:subject>Roman Historique</dc:subject>
+    <dc:subject>Les Enfants de la Terre</dc:subject>
+    <dc:subject>Fiction</dc:subject>
+    <dc:language>fr</dc:language>
+    <dc:identifier opf:scheme="calibre">a2cf2f25-4de2-4f77-82cc-0198352b0851</dc:identifier>
+    <dc:identifier opf:scheme="GOOGLE">63CTHAAACAAJ</dc:identifier>
+    <dc:identifier opf:scheme="ISBN">9782266122122</dc:identifier>
+    <meta name="calibre:title_sort" content="clan de l'ours des cavernes, Le" />
+    <meta name="calibre:series" content="Les Enfants de la Terre" />
+    <meta name="calibre:series_index" content="1.0" />
+    <meta name="calibre:timestamp" content="2023-03-25T10:32:21+00:00" />
+    <meta name="calibre:rating" content="10.0" />
+    <meta name="cover" content="cover" />
+    <meta name="calibre:author_link_map" content="{&quot;Jean M. Auel&quot;: &quot;&quot;}" />
+  </metadata>
+  <manifest>
+    <item id="titlepage" href="titlepage.xhtml" media-type="application/xhtml+xml" />
+    <item id="html8"
+      href="Auel,Jean M.-[Les Enfants de la Terre-1]Le clan de l'ours des cavernes.French.ebook.AlexandriZ_split_000.htm"
+      media-type="application/xhtml+xml" />
+    <item id="html7"
+      href="Auel,Jean M.-[Les Enfants de la Terre-1]Le clan de l'ours des cavernes.French.ebook.AlexandriZ_split_001.htm"
+      media-type="application/xhtml+xml" />
+    <item id="html6"
+      href="Auel,Jean M.-[Les Enfants de la Terre-1]Le clan de l'ours des cavernes.French.ebook.AlexandriZ_split_002.htm"
+      media-type="application/xhtml+xml" />
+    <item id="html5"
+      href="Auel,Jean M.-[Les Enfants de la Terre-1]Le clan de l'ours des cavernes.French.ebook.AlexandriZ_split_003.htm"
+      media-type="application/xhtml+xml" />
+    <item id="html4"
+      href="Auel,Jean M.-[Les Enfants de la Terre-1]Le clan de l'ours des cavernes.French.ebook.AlexandriZ_split_004.htm"
+      media-type="application/xhtml+xml" />
+    <item id="html3"
+      href="Auel,Jean M.-[Les Enfants de la Terre-1]Le clan de l'ours des cavernes.French.ebook.AlexandriZ_split_005.htm"
+      media-type="application/xhtml+xml" />
+    <item id="html2"
+      href="Auel,Jean M.-[Les Enfants de la Terre-1]Le clan de l'ours des cavernes.French.ebook.AlexandriZ_split_006.htm"
+      media-type="application/xhtml+xml" />
+    <item id="html1"
+      href="Auel,Jean M.-[Les Enfants de la Terre-1]Le clan de l'ours des cavernes.French.ebook.AlexandriZ_split_007.htm"
+      media-type="application/xhtml+xml" />
+    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
+    <item id="page_css" href="page_styles.css" media-type="text/css" />
+    <item id="css" href="stylesheet.css" media-type="text/css" />
+    <item id="cover" href="cover.jpeg" media-type="image/jpeg" />
+  </manifest>
+  <spine toc="ncx">
+    <itemref idref="titlepage" />
+    <itemref idref="html8" />
+    <itemref idref="html7" />
+    <itemref idref="html6" />
+    <itemref idref="html5" />
+    <itemref idref="html4" />
+    <itemref idref="html3" />
+    <itemref idref="html2" />
+    <itemref idref="html1" />
+  </spine>
+  <guide>
+    <reference type="cover" href="titlepage.xhtml" title="Cover" />
+  </guide>
+</package>

--- a/tests/media/opf-epub2-multiple-authors.opf
+++ b/tests/media/opf-epub2-multiple-authors.opf
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0" unique-identifier="uuid_id">
+  <metadata xmlns:opf="http://www.idpf.org/2007/opf" xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:calibre="http://calibre.kovidgoyal.net/2009/metadata">
+    <dc:title>Le clan de l'ours des cavernes</dc:title>
+    <dc:creator opf:role="aut" opf:file-as="Auel, Jean M.">Jean M. Auel</dc:creator>
+    <dc:creator opf:role="aut">Philippe Rouard</dc:creator>
+    <dc:contributor opf:role="bkp">calibre (6.12.0) [https://calibre-ebook.com]</dc:contributor>
+    <dc:description>&lt;div&gt;
+      &lt;p&gt;Quelque part en Europe, 35 000 ans avant notre ère. Petite fille Cro-Magnon de cinq
+      ans, Ayla est séparée de ses parents à la suite d'un violent tremblement de terre. Elle est
+      recueillie par le clan de l'ours des cavernes, une tribu Neandertal qui l'adopte, non sans
+      réticence, ayant reconnu en elle la représentante d'une autre espèce, plus évoluée.
+      &lt;br&gt;&lt;br&gt;Iza, la guérisseuse, Brun, le chef et Creb, le magicien lui enseignent les
+      règles de la vie communautaire, leurs rites, leurs peurs, leurs audaces. Mais Ayla, la
+      fillette blonde aux yeux bleus les surprend par sa puissance de raisonnement qui lui permet de
+      s'adapter, de réagir rapidement et de ne pas être totalement dépendante de son environnement.
+      Une différence qui ne tarde pas à faire d'elle une menace pour tout le clan, et à attiser la
+      convoitise de Brud, le fils du chef...&lt;/p&gt;&lt;/div&gt;</dc:description>
+    <dc:publisher>Presses de la cité</dc:publisher>
+    <dc:identifier id="uuid_id" opf:scheme="uuid">a2cf2f25-4de2-4f77-82cc-0198352b0851</dc:identifier>
+    <dc:date>1980-01-13T21:00:00+00:00</dc:date>
+    <dc:subject>Roman Historique</dc:subject>
+    <dc:subject>Les Enfants de la Terre</dc:subject>
+    <dc:subject>Fiction</dc:subject>
+    <dc:language>fr</dc:language>
+    <dc:identifier opf:scheme="calibre">a2cf2f25-4de2-4f77-82cc-0198352b0851</dc:identifier>
+    <dc:identifier opf:scheme="GOOGLE">63CTHAAACAAJ</dc:identifier>
+    <dc:identifier opf:scheme="ISBN">9782266122122</dc:identifier>
+    <meta name="calibre:title_sort" content="clan de l'ours des cavernes, Le" />
+    <meta name="calibre:series" content="Les Enfants de la Terre" />
+    <meta name="calibre:series_index" content="1.0" />
+    <meta name="calibre:timestamp" content="2023-03-25T10:32:21+00:00" />
+    <meta name="calibre:rating" content="10.0" />
+    <meta name="cover" content="cover" />
+    <meta name="calibre:author_link_map" content="{&quot;Jean M. Auel&quot;: &quot;&quot;}" />
+  </metadata>
+  <manifest>
+    <item id="titlepage" href="titlepage.xhtml" media-type="application/xhtml+xml" />
+    <item id="html8"
+      href="Auel,Jean M.-[Les Enfants de la Terre-1]Le clan de l'ours des cavernes.French.ebook.AlexandriZ_split_000.htm"
+      media-type="application/xhtml+xml" />
+    <item id="html7"
+      href="Auel,Jean M.-[Les Enfants de la Terre-1]Le clan de l'ours des cavernes.French.ebook.AlexandriZ_split_001.htm"
+      media-type="application/xhtml+xml" />
+    <item id="html6"
+      href="Auel,Jean M.-[Les Enfants de la Terre-1]Le clan de l'ours des cavernes.French.ebook.AlexandriZ_split_002.htm"
+      media-type="application/xhtml+xml" />
+    <item id="html5"
+      href="Auel,Jean M.-[Les Enfants de la Terre-1]Le clan de l'ours des cavernes.French.ebook.AlexandriZ_split_003.htm"
+      media-type="application/xhtml+xml" />
+    <item id="html4"
+      href="Auel,Jean M.-[Les Enfants de la Terre-1]Le clan de l'ours des cavernes.French.ebook.AlexandriZ_split_004.htm"
+      media-type="application/xhtml+xml" />
+    <item id="html3"
+      href="Auel,Jean M.-[Les Enfants de la Terre-1]Le clan de l'ours des cavernes.French.ebook.AlexandriZ_split_005.htm"
+      media-type="application/xhtml+xml" />
+    <item id="html2"
+      href="Auel,Jean M.-[Les Enfants de la Terre-1]Le clan de l'ours des cavernes.French.ebook.AlexandriZ_split_006.htm"
+      media-type="application/xhtml+xml" />
+    <item id="html1"
+      href="Auel,Jean M.-[Les Enfants de la Terre-1]Le clan de l'ours des cavernes.French.ebook.AlexandriZ_split_007.htm"
+      media-type="application/xhtml+xml" />
+    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
+    <item id="page_css" href="page_styles.css" media-type="text/css" />
+    <item id="css" href="stylesheet.css" media-type="text/css" />
+    <item id="cover" href="cover.jpeg" media-type="image/jpeg" />
+  </manifest>
+  <spine toc="ncx">
+    <itemref idref="titlepage" />
+    <itemref idref="html8" />
+    <itemref idref="html7" />
+    <itemref idref="html6" />
+    <itemref idref="html5" />
+    <itemref idref="html4" />
+    <itemref idref="html3" />
+    <itemref idref="html2" />
+    <itemref idref="html1" />
+  </spine>
+  <guide>
+    <reference type="cover" href="titlepage.xhtml" title="Cover" />
+  </guide>
+</package>


### PR DESCRIPTION
-   `MetaTitle::class` : now native slugifier is fixed, float volume works now, volume use `000` padding.
-   Allow authors with `,`, `;` and `&` in the name for `.opf`, `.pdf`, `.mobi` and audiobooks.