### PR TITLE
v2.5.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kiwilan/php-ebook",
     "description": "PHP package to read metadata and extract covers from eBooks, comics and audiobooks.",
-    "version": "2.5.10",
+    "version": "2.5.11",
     "keywords": [
         "php",
         "ebook",

--- a/src/Utils/EbookUtils.php
+++ b/src/Utils/EbookUtils.php
@@ -17,13 +17,13 @@ class EbookUtils
             return $content;
         }
 
-        if (str_contains($content, ',')) {
+        if (str_contains($content, ', ')) {
             $content = explode(',', $content);
         } elseif (str_contains($content, ';')) {
             $content = explode(';', $content);
-        } elseif (str_contains($content, '&')) {
+        } elseif (str_contains($content, ' & ')) {
             $content = explode('&', $content);
-        } elseif (str_contains($content, 'and')) {
+        } elseif (str_contains($content, ' and ')) {
             $content = explode('and', $content);
         } elseif (str_contains($content, '/')) {
             $content = explode('/', $content);


### PR DESCRIPTION
`EbookUtils::class` fix `parseStringWithSeperator()` method.