### PR TITLE
v2.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,14 @@ $ebook = Ebook::read('path/to/ebook.epub');
 $metaTitle = $ebook->getMetaTitle(); // ?MetaTitle
 
 $metaTitle->getSlug(); // string => slug title, like `lord-of-the-rings-en-01-fellowship-of-the-ring-j-r-r-tolkien-1954-epub`
-$metaTitle->getSlugSimple(); // string => slug title simple, like `the-fellowship-of-the-ring`
-$metaTitle->getSeriesSlug(); // ?string => slug series title, like `lord-of-the-rings-en-j-r-r-tolkien-epub`
-$metaTitle->getSeriesSlugSimple(); // ?string => slug series title simple, like `the-lord-of-the-rings`
+$metaTitle->getSeriesSlug(); // ?string => slug series title, like `lord-of-the-rings-en-epub`
+```
+
+You can customize slug with `MetaTitle::class`:
+
+```php
+$meta->getSlug(removeDeterminers: true, addSeries: true, addVolume: true, addAuthor: true, addYear: true, addExtension: true, addLanguage: true);
+$meta->getSeriesSlug(removeDeterminers: true, addAuthor: false, addExtension: true, addLanguage: true);
 ```
 
 ### Cover

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 PHP package to read metadata and extract covers from eBooks, comics and audiobooks.
 
+> Because metadata are the key against chaos.
+
 -   eBooks: `.epub`, `.pdf`, `.azw`, `.azw3`, `.kf8`, `.kfx`, `.mobi`, `.prc`, `.fb2`
 -   Comics: `.cbz`, `.cbr`, `.cb7`, `.cbt` (metadata from [github.com/anansi-project](https://github.com/anansi-project))
 -   Audiobooks: `.mp3`, `.m4a`, `.m4b`, `.flac`, `.ogg` with external package[`kiwilan/php-audio`](https://github.com/kiwilan/php-audio) (**MUST** be installed separately)

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kiwilan/php-ebook",
     "description": "PHP package to read metadata and extract covers from eBooks, comics and audiobooks.",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "keywords": [
         "php",
         "ebook",

--- a/src/Models/MetaTitle.php
+++ b/src/Models/MetaTitle.php
@@ -293,8 +293,7 @@ class MetaTitle
         protected ?string $seriesDeterminer = null,
 
         protected bool $useIntl = true,
-    ) {
-    }
+    ) {}
 
     /**
      * Create a new MetaTitle instance from an Ebook.

--- a/tests/EpubTest.php
+++ b/tests/EpubTest.php
@@ -73,7 +73,7 @@ it('can get title meta', function () {
     $meta = $ebook->getMetaTitle();
 
     expect($meta->getSlug())->toBe('earths-children-en-001-clan-of-the-cave-bear-jean-m-auel-1980-epub');
-    expect($meta->getSeriesSlug())->toBe('earths-children-en-jean-m-auel-epub');
+    expect($meta->getSeriesSlug())->toBe('earths-children-en-epub');
 
     expect($meta->toArray())->toBeArray();
     expect($meta->__toString())->toBeString();

--- a/tests/MetaTitleTest.php
+++ b/tests/MetaTitleTest.php
@@ -15,9 +15,14 @@ it('can be slugify', function () {
     $meta = MetaTitle::fromEbook($ebook);
 
     expect($meta->getSlug())->toBe('a-comme-association-fr-001-pale-lumiere-des-tenebres-pierre-bottero-1980-epub');
+    expect($meta->getSeriesSlug())->toBe('a-comme-association-fr-epub');
+    // deprecated
     expect($meta->getSlugSimple())->toBe('la-pale-lumiere-des-tenebres');
-    expect($meta->getSeriesSlug())->toBe('a-comme-association-fr-pierre-bottero-epub');
     expect($meta->getSeriesSlugSimple())->toBe('a-comme-association');
+});
+
+it('can use setters', function () {
+    $ebook = Ebook::read(EPUB);
 
     $ebook->setTitle('The Fellowship of the Ring');
     $ebook->setVolume(1);
@@ -27,8 +32,9 @@ it('can be slugify', function () {
     $meta = MetaTitle::fromEbook($ebook);
 
     expect($meta->getSlug())->toBe('lord-of-the-rings-en-001-fellowship-of-the-ring-j-r-r-tolkien-1980-epub');
+    expect($meta->getSeriesSlug())->toBe('lord-of-the-rings-en-epub');
+    // deprecated
     expect($meta->getSlugSimple())->toBe('the-fellowship-of-the-ring');
-    expect($meta->getSeriesSlug())->toBe('lord-of-the-rings-en-j-r-r-tolkien-epub');
     expect($meta->getSeriesSlugSimple())->toBe('the-lord-of-the-rings');
 
     $ebook->setTitle('Artemis');
@@ -39,10 +45,13 @@ it('can be slugify', function () {
     $meta = MetaTitle::fromEbook($ebook);
 
     expect($meta->getSlug())->toBe('artemis-en-andy-weir-1980-epub');
-    expect($meta->getSlugSimple())->toBe('artemis');
     expect($meta->getSeriesSlug())->toBeNull();
+    // deprecated
+    expect($meta->getSlugSimple())->toBe('artemis');
     expect($meta->getSeriesSlugSimple())->toBeNull();
+});
 
+it('can use from data', function () {
     $meta = MetaTitle::fromData(
         title: 'The Fellowship of the Ring',
         volume: 1,
@@ -54,8 +63,9 @@ it('can be slugify', function () {
     );
 
     expect($meta->getSlug())->toBe('lord-of-the-rings-en-001-fellowship-of-the-ring-j-r-r-tolkien-1980-epub');
+    expect($meta->getSeriesSlug())->toBe('lord-of-the-rings-en-epub');
+    // deprecated
     expect($meta->getSlugSimple())->toBe('the-fellowship-of-the-ring');
-    expect($meta->getSeriesSlug())->toBe('lord-of-the-rings-en-j-r-r-tolkien-epub');
     expect($meta->getSeriesSlugSimple())->toBe('the-lord-of-the-rings');
 });
 
@@ -71,8 +81,9 @@ it('can slug without intl', function () {
     );
 
     expect($meta->getSlug())->toBe('a-comme-association-fr-001.5-pale-lumiere-des-tenebres-pierre-bottero-epub');
+    expect($meta->getSeriesSlug())->toBe('a-comme-association-fr-epub');
+    // deprecated
     expect($meta->getSlugSimple())->toBe('la-pale-lumiere-des-tenebres');
-    expect($meta->getSeriesSlug())->toBe('a-comme-association-fr-pierre-bottero-epub');
     expect($meta->getSeriesSlugSimple())->toBe('a-comme-association');
 });
 
@@ -106,4 +117,113 @@ it('can use determiner title', function () {
     $meta = MetaTitle::fromEbook($ebook);
 
     expect($meta->getSlug())->toBe('assassin-royal-fr-050-apprenti-assassin-robin-hobb-1980-epub');
+});
+
+it('can use params', function () {
+    $ebook = Ebook::read(EPUB);
+
+    $ebook->setTitle('La pâle lumière des ténèbres');
+    $ebook->setVolume(1);
+    $ebook->setSeries('A comme Association');
+    $ebook->setLanguage('fr');
+    $ebook->setAuthorMain(new BookAuthor('Pierre Bottero'));
+    $meta = MetaTitle::fromEbook($ebook);
+
+    expect($meta->getSlug(
+        removeDeterminers: true,
+        addSeries: true,
+        addVolume: true,
+        addAuthor: true,
+        addYear: true,
+        addExtension: true,
+        addLanguage: true,
+    ))->toBe('a-comme-association-fr-001-pale-lumiere-des-tenebres-pierre-bottero-1980-epub');
+    expect($meta->getSlug(
+        removeDeterminers: false,
+        addSeries: true,
+        addVolume: true,
+        addAuthor: true,
+        addYear: true,
+        addExtension: true,
+        addLanguage: true,
+    ))->toBe('a-comme-association-fr-001-la-pale-lumiere-des-tenebres-pierre-bottero-1980-epub');
+    expect($meta->getSlug(
+        removeDeterminers: false,
+        addSeries: false,
+        addVolume: true,
+        addAuthor: true,
+        addYear: true,
+        addExtension: true,
+        addLanguage: true,
+    ))->toBe('fr-001-la-pale-lumiere-des-tenebres-pierre-bottero-1980-epub');
+    expect($meta->getSlug(
+        removeDeterminers: false,
+        addSeries: false,
+        addVolume: false,
+        addAuthor: true,
+        addYear: true,
+        addExtension: true,
+        addLanguage: true,
+    ))->toBe('fr-la-pale-lumiere-des-tenebres-pierre-bottero-1980-epub');
+    expect($meta->getSlug(
+        removeDeterminers: false,
+        addSeries: false,
+        addVolume: false,
+        addAuthor: false,
+        addYear: true,
+        addExtension: true,
+        addLanguage: true,
+    ))->toBe('fr-la-pale-lumiere-des-tenebres-1980-epub');
+    expect($meta->getSlug(
+        removeDeterminers: false,
+        addSeries: false,
+        addVolume: false,
+        addAuthor: false,
+        addYear: false,
+        addExtension: true,
+        addLanguage: true,
+    ))->toBe('fr-la-pale-lumiere-des-tenebres-epub');
+    expect($meta->getSlug(
+        removeDeterminers: false,
+        addSeries: false,
+        addVolume: false,
+        addAuthor: false,
+        addYear: false,
+        addExtension: false,
+        addLanguage: true,
+    ))->toBe('fr-la-pale-lumiere-des-tenebres');
+    expect($meta->getSlug(
+        removeDeterminers: false,
+        addSeries: false,
+        addVolume: false,
+        addAuthor: false,
+        addYear: false,
+        addExtension: false,
+        addLanguage: false,
+    ))->toBe('la-pale-lumiere-des-tenebres');
+
+    expect($meta->getSeriesSlug(
+        removeDeterminers: false,
+        addAuthor: true,
+        addExtension: true,
+        addLanguage: true,
+    ))->toBe('a-comme-association-fr-pierre-bottero-epub');
+    expect($meta->getSeriesSlug(
+        removeDeterminers: false,
+        addAuthor: false,
+        addExtension: true,
+        addLanguage: true,
+    ))->toBe('a-comme-association-fr-epub');
+    expect($meta->getSeriesSlug(
+        removeDeterminers: false,
+        addAuthor: false,
+        addExtension: false,
+        addLanguage: true,
+    ))->toBe('a-comme-association-fr');
+    expect($meta->getSeriesSlug(
+        removeDeterminers: false,
+        addAuthor: false,
+        addExtension: false,
+        addLanguage: false,
+    ))->toBe('a-comme-association');
 });


### PR DESCRIPTION
Refactor `MetaTitle::class`

-   `getSeriesSlugSimple()`, `getSlugSimple()` are deprecated
-   `getSlug()` have now multiple parameters to customize the slug: `removeDeterminers`, `addSeries`, `addVolume`, `addAuthor`, `addYear`, `addExtension`, `addLanguage` (all are `true` by default)
-   `getSeriesSlug()` have now multiple parameters to customize the slug: `removeDeterminers`, `addAuthor`, `addExtension`, `addLanguage` (`removeDeterminers`, `addExtension`, `addLanguage` are `true` by default, `addAuthor` is `false` by default)