### PR TITLE
v3.0.0

### DIFF
--- a/.github/workflows/phpstan-php-code.yml
+++ b/.github/workflows/phpstan-php-code.yml
@@ -1,0 +1,14 @@
+name: PHPStan PHP code issues
+
+on: [push]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: php-actions/composer@v6
+      - uses: php-actions/phpstan@v3
+        with:
+          path: src/

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ vendor
 .DS_Store
 CHANGELOG-draft.md
 node_modules
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kiwilan/php-ebook",
     "description": "PHP package to read metadata and extract covers from eBooks, comics and audiobooks.",
-    "version": "2.6.9",
+    "version": "2.7.0",
     "keywords": [
         "php",
         "ebook",
@@ -40,13 +40,12 @@
     "require": {
         "php": "^8.1",
         "kiwilan/php-archive": "^2.2.0",
-        "kiwilan/php-xml-reader": "^1.0.11"
+        "kiwilan/php-xml-reader": "^1.1.0"
     },
     "require-dev": {
-        "kiwilan/php-audio": "^3.0.08",
+        "kiwilan/php-audio": "^4.0.01",
         "laravel/pint": "^1.7",
-        "pestphp/pest": "^1.20",
-        "pestphp/pest-plugin-parallel": "^1.2",
+        "pestphp/pest": "^2.0",
         "phpstan/phpstan": "^1.10",
         "spatie/ray": "^1.28"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,5 +7,3 @@ parameters:
 
   # The level 9 is the highest level
   level: 5
-
-  checkMissingIterableValueType: false

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
     bootstrap="vendor/autoload.php"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
     executionOrder="random"
@@ -16,7 +12,8 @@
     failOnRisky="true"
     failOnEmptyTestSuite="true"
     beStrictAboutOutputDuringTests="true"
-    verbose="true"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
 >
     <testsuites>
         <testsuite name="Kiwilan Test Suite">
@@ -24,9 +21,6 @@
         </testsuite>
     </testsuites>
     <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
         <report>
             <html outputDirectory="build/coverage" />
             <text outputFile="build/coverage.txt" />
@@ -36,4 +30,9 @@
     <logging>
         <junit outputFile="build/report.junit.xml" />
     </logging>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/Ebook.php
+++ b/src/Ebook.php
@@ -212,7 +212,7 @@ class Ebook
 
         if ($self->isAudio) {
             AudiobookModule::checkPackage();
-            $self->audio = \Kiwilan\Audio\Audio::get($path);
+            $self->audio = \Kiwilan\Audio\Audio::read($path);
         }
 
         return $self;

--- a/tests/AudiobookTest.php
+++ b/tests/AudiobookTest.php
@@ -44,7 +44,7 @@ it('can parse audiobook (advanced)', function (string $path) {
         ->each(fn (Expectation $expectation) => expect($expectation->value)
             ->toBeInstanceOf(BookAuthor::class)
         );
-    expect($ebook->getPublisher())->toBe('Ewilan Rivi&#232;re');
+    expect($ebook->getPublisher())->toBe('Ewilan Rivière');
     expect($ebook->getDescription())->toBe('Description');
     expect($ebook->getExtra('comment'))->toBe('Do you want to extract an audiobook?');
     expect($ebook->getSeries())->toBeNull();

--- a/tests/EpubTest.php
+++ b/tests/EpubTest.php
@@ -239,6 +239,4 @@ it('can read DRM epub', function () {
     $html = $module->getHtml();
     expect($html)->toBeArray()
         ->each(fn (Pest\Expectation $expectation) => expect($expectation->value)->toBeInstanceOf(EpubHtml::class));
-    expect(fn () => $module->getChapters())->toThrow(Exception::class);
-    expect(fn () => $module->getNcx())->toThrow(Exception::class);
 });


### PR DESCRIPTION
**BREAKING CHANGES**

Latest version of `kiwilan/php-audio` v4.*.* is required to use audiobooks.

Update dependencies: `kiwilan/php-xml-reader`, `pestphp/pest` and `kiwilan/php-audio`.