### PR TITLE
v3.0.01

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kiwilan/php-ebook",
     "description": "PHP package to read metadata and extract covers from eBooks, comics and audiobooks.",
-    "version": "2.7.0",
+    "version": "3.0.01",
     "keywords": [
         "php",
         "ebook",


### PR DESCRIPTION
**BREAKING CHANGES**

Latest version of `kiwilan/php-audio` v4.*.* is required to use audiobooks.

Update dependencies: `kiwilan/php-xml-reader`, `pestphp/pest` and `kiwilan/php-audio`.
