### PR TITLE
Prevent counting on null

### DIFF
--- a/src/Formats/Mobi/Parser/MobiParser.php
+++ b/src/Formats/Mobi/Parser/MobiParser.php
@@ -43,7 +43,7 @@ class MobiParser
     {
         $data = $this->getRecordData($record);
 
-        if ($asArray) {
+        if ($asArray || $data === null) {
             return $data;
         }
 


### PR DESCRIPTION
Salut! I got an [error reported](https://github.com/biblioverse/biblioteca/issues/226) when parsing a Mobi file. This would prevent it

```
 "exception" => TypeError {
    #message: "count(): Argument #1 ($value) must be of type Countable|array, null given"
    #code: 0
    #file: "./vendor/kiwilan/php-ebook/src/Formats/Mobi/Parser/MobiParser.php"
    #line: 50
    trace: {
      ./vendor/kiwilan/php-ebook/src/Formats/Mobi/Parser/MobiParser.php:50 { …}
      ./vendor/kiwilan/php-ebook/src/Formats/Mobi/MobiModule.php:51 { …}
      ./vendor/kiwilan/php-ebook/src/Ebook.php:284 { …}
      ./vendor/kiwilan/php-ebook/src/Ebook.php:113 { …}
```
