### PR TITLE
The PDF Author can sometimes be an empty string

### DIFF
--- a/src/Formats/Pdf/PdfModule.php
+++ b/src/Formats/Pdf/PdfModule.php
@@ -27,7 +27,7 @@ class PdfModule extends EbookModule
 
         $author = $this->meta?->getAuthor();
 
-        if ($author !== null) {
+        if ($author !== null && $author !== '') {
             $authors = EbookUtils::parseStringWithSeperator($author);
 
             $creators = [];


### PR DESCRIPTION
Hi,

I'm contributing these fixes to this library as it is used in the https://github.com/biblioverse/biblioteca project, more specifically to scan ebooks.

One error I've encountered is that the Author might be empty in a PDF and this results in the following error

```
Warning: foreach() argument must be of type array|object, null given
```

Checking for empty strings makes the error disappear.

> note for me: This partially fixes https://github.com/biblioverse/biblioteca/issues/317