### PR TITLE
Added getEpubVersionString to OpfItem

### DIFF
--- a/src/Formats/Epub/Parser/OpfItem.php
+++ b/src/Formats/Epub/Parser/OpfItem.php
@@ -25,6 +25,7 @@ class OpfItem
     protected array $guide = [];
 
     protected ?int $epubVersion = null;
+    protected ?string $epubVersionString = null;
 
     protected ?string $filename = null;
 
@@ -71,6 +72,7 @@ class OpfItem
 
         $content = $xml->getContents();
         $self->epubVersion = $self->xml->getRootAttribute('version');
+        $self->epubVersionString = $self->xml->getRootAttribute('version');
         $metadata = $content['metadata'] ?? $content['opf:metadata'] ?? [];
         $manifest = $content['manifest'] ?? $content['opf:manifest'] ?? [];
 
@@ -235,6 +237,11 @@ class OpfItem
     public function getEpubVersion(): ?int
     {
         return $this->epubVersion;
+    }
+
+    public function getEpubVersionString(): ?string
+    {
+        return $this->epubVersionString;
     }
 
     public function getDcTitle(): ?string

--- a/tests/OpfTest.php
+++ b/tests/OpfTest.php
@@ -42,6 +42,8 @@ it('can parse epub opf', function (string $path) {
     expect($opf->getMetaItems())->toBeArray();
     expect($opf->getCoverPath())->toBeString();
     expect($opf->getEpubVersion())->toBeGreaterThanOrEqual(2);
+    expect($opf->getEpubVersionString())->toBeString();
+    expect($opf->getEpubVersionString())->toMatch('/^[2-3]\.\d*/');
 })->with([EPUB_OPF_EPUB2, EPUB_OPF_EPUB3, EPUB_OPF_INSURGENT, EPUB_OPF_LAGUERREETERNELLE, EPUB_OPF_EPEEETMORT, EPUB_OPF_NOT_FORMATTED]);
 
 it('can parse epub opf meta items', function () {


### PR DESCRIPTION
The current getEpubVersion returns only int, which is unsufficient for our use when we would need to the exact ePub version number (2.0.1, 3.0, 3.3 and so on). Instead of changing the current functionality, I added a new getEpubVersionString method to OPF parser which returns the full version as string. 