### PR TITLE
Improved error handling & format override

### DIFF
--- a/src/Ebook.php
+++ b/src/Ebook.php
@@ -89,10 +89,10 @@ class Ebook
     /**
      * Read an ebook file.
      */
-    public static function read(string $path): ?self
+    public static function read(string $path, ?string $format = null): ?self
     {
         $start = microtime(true);
-        $self = self::parseFile($path);
+        $self = self::parseFile($path, $format);
 
         $format = match ($self->format) {
             EbookFormatEnum::AUDIOBOOK => $self->audiobook(),
@@ -142,11 +142,11 @@ class Ebook
     /**
      * Parse an ebook file.
      */
-    private static function parseFile(string $path): Ebook
+    private static function parseFile(string $path, ?string $format = null): Ebook
     {
         $basename = pathinfo($path, PATHINFO_BASENAME);
         $filename = pathinfo($path, PATHINFO_FILENAME);
-        $extension = pathinfo($path, PATHINFO_EXTENSION);
+        $extension = $format ?? pathinfo($path, PATHINFO_EXTENSION);
 
         $cbaExtensions = ['cbz', 'cbr', 'cb7', 'cbt'];
         $archiveExtensions = ['epub', 'pdf', ...$cbaExtensions];


### PR DESCRIPTION
- throws Exception if unable to detect extension (for example, the file comes from a php upload or is stored in the file system under an unrelated name)
- Ebook::read allows you to specify the extension of the file being parsed as the second parameter, which will force the format to be selected by the user.