### PR TITLE
v3.0.09

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,6 @@ To know more see [Supported formats](#supported-formats). _Supports Linux, macOS
 >
 > For DRM (Digital Rights Management) eBooks, in some cases you could read metadata but not contents (like HTML files for EPUB). To use all features, you have to use a software to remove DRM before using this package. For EPUB, you can use [calibre](https://calibre-ebook.com/) with [DeDRM plugin](https://github.com/noDRM/DeDRM_tools), [this guide](https://www.epubor.com/calibre-drm-removal-plugins.html) can help you.
 
-## About
-
-This package was built for [`bookshelves-project/bookshelves`](https://github.com/bookshelves-project/bookshelves), a web app to handle eBooks.
-
 ## Requirements
 
 -   **PHP version** `>=8.1`

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kiwilan/php-ebook",
     "description": "PHP package to read metadata and extract covers from eBooks, comics and audiobooks.",
-    "version": "3.0.08",
+    "version": "3.0.09",
     "keywords": [
         "php",
         "ebook",
@@ -39,10 +39,11 @@
     ],
     "require": {
         "php": "^8.1",
-        "kiwilan/php-archive": "^2.3.01",
+        "kiwilan/php-archive": "^2.3.02",
         "kiwilan/php-xml-reader": "^1.1.0"
     },
     "require-dev": {
+        "illuminate/support": "^9.0 || ^10.0 || ^11.0 || ^12.0",
         "kiwilan/php-audio": "^4.0.01",
         "laravel/pint": "^1.7",
         "pestphp/pest": "^2.0",

--- a/src/Ebook.php
+++ b/src/Ebook.php
@@ -140,7 +140,7 @@ class Ebook
     }
 
     /**
-     * Parse an ebook file.
+     * Parse an ebook file
      */
     private static function parseFile(string $path, ?string $format = null): Ebook
     {
@@ -207,8 +207,28 @@ class Ebook
                 $archive = Archive::read($path);
                 $self->archive = $archive;
             } catch (\Throwable $th) {
-                error_log("Error reading archive: {$path}");
+                $msg = "`kiwikan/php-ebook` error with archive {$path}";
                 $self->isBadFile = true;
+
+                $error = [
+                    'message' => $th->getMessage(),
+                    'code' => $th->getCode(),
+                    'file' => $th->getFile(),
+                    'line' => $th->getLine(),
+                    'trace' => $th->getTraceAsString(),
+                ];
+
+                $log = $msg.' | '.print_r($error, true);
+                if (class_exists(\Illuminate\Support\Facades\Log::class)) {
+                    try {
+                        \Illuminate\Support\Facades\Log::error($msg, $error);
+                    } catch (\Throwable $th) {
+                        error_log($log);
+                    }
+                } else {
+                    error_log($log);
+                }
+
             }
         }
 

--- a/src/EbookCover.php
+++ b/src/EbookCover.php
@@ -61,6 +61,22 @@ class EbookCover
         return base64_decode($this->contents);
     }
 
+    /**
+     * Save the cover contents to a file.
+     *
+     * @param  string  $path  The file path to save the contents to, e.g. `/path/to/cover.jpg`
+     */
+    public function saveTo(string $path): bool
+    {
+        $contents = $this->getContents();
+
+        if ($contents === null) {
+            return false;
+        }
+
+        return file_put_contents($path, $contents) !== false;
+    }
+
     public function toArray(): array
     {
         return [

--- a/tests/EpubTest.php
+++ b/tests/EpubTest.php
@@ -240,6 +240,9 @@ it('can read DRM epub', function () {
     $html = $module->getHtml();
     expect($html)->toBeArray()
         ->each(fn (Pest\Expectation $expectation) => expect($expectation->value)->toBeInstanceOf(EpubHtml::class));
+
+    $ebook->getCover()->saveTo('tests/output/cover-EPUB-DRM-save.jpg');
+    expect(file_exists('tests/output/cover-EPUB-DRM-save.jpg'))->toBeTrue();
 });
 
 it('can get epub chapters', function () {


### PR DESCRIPTION
- Upgrade `kiwilan/php-archive`
- Improve error logging if an archive is invalid with Laravel `illuminate/support` (optional and if installed) otherwise use `error_log()`
- Add `saveTo()` method to `EbookCover` class

```php
public function saveTo(string $path): bool
```